### PR TITLE
fix pagination default 10 result by default

### DIFF
--- a/src/Client/RedisClient.php
+++ b/src/Client/RedisClient.php
@@ -265,7 +265,7 @@ final class RedisClient implements RedisClientInterface
     /**
      * @inheritdoc
      */
-    public function search(string $prefixKey, array $search, array $orderBy, ?string $format = RedisFormat::HASH->value, ?int $numberOfResults = null, ?string $searchType = Property::INDEX_TAG): array
+    public function search(string $prefixKey, array $search, array $orderBy, ?string $format = RedisFormat::HASH->value, ?int $numberOfResults = null, int $offset = 0, ?string $searchType = Property::INDEX_TAG): array
     {
         $arguments = [RedisCommands::SEARCH->value, self::convertPrefix($prefixKey)];
 
@@ -288,6 +288,11 @@ final class RedisClient implements RedisClientInterface
             $arguments[] = 'SORTBY';
             $arguments[] = $property;
             $arguments[] = $direction;
+        }
+        if ($numberOfResults !== null) {
+            $arguments[] = 'LIMIT';
+            $arguments[] = $offset;
+            $arguments[] = $numberOfResults;
         }
 
         try {

--- a/src/Client/RedisClientInterface.php
+++ b/src/Client/RedisClientInterface.php
@@ -80,7 +80,7 @@ interface RedisClientInterface
     /**
      * Search objects by given prefix key and criterias.
      */
-    public function search(string $prefixKey, array $search, array $orderBy, ?string $format = RedisFormat::HASH->value, ?int $numberOfResults = null, ?string $searchType = Property::INDEX_TAG): array;
+    public function search(string $prefixKey, array $search, array $orderBy, ?string $format = RedisFormat::HASH->value, ?int $numberOfResults = null, int $offset = 0, ?string $searchType = Property::INDEX_TAG): array;
 
     /**
      * Search objects by given prefix and a complete custom query command.

--- a/src/Command/GenerateSchema.php
+++ b/src/Command/GenerateSchema.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace  Talleu\RedisOm\Command;
+namespace Talleu\RedisOm\Command;
 
 use Talleu\RedisOm\Exception\BadIdentifierConfigurationException;
 use Talleu\RedisOm\Om\Converters\AbstractDateTimeConverter;

--- a/src/Console/Runner.php
+++ b/src/Console/Runner.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace  Talleu\RedisOm\Console;
+namespace Talleu\RedisOm\Console;
 
 use Talleu\RedisOm\Command\GenerateSchema;
 

--- a/src/Om/Persister/ObjectToPersist.php
+++ b/src/Om/Persister/ObjectToPersist.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace  Talleu\RedisOm\Om\Persister;
+namespace Talleu\RedisOm\Om\Persister;
 
 use Talleu\RedisOm\Om\Converters\ConverterInterface;
 


### PR DESCRIPTION
limits the results to the offset and number of results given. Note that the offset is zero-indexed. The default is 0 10, which returns 10 items starting from the first result. You can use LIMIT 0 0 to count the number of documents in the result set without actually returning them.