### PR TITLE
Use a non-nullable property for redisClient

### DIFF
--- a/src/Om/RedisObjectManager.php
+++ b/src/Om/RedisObjectManager.php
@@ -27,9 +27,10 @@ final class RedisObjectManager implements RedisObjectManagerInterface
     /** @var array<string, array<string, ObjectToPersist[]>> */
     protected array $objectsToFlush = [];
     protected ?KeyGenerator $keyGenerator = null;
+    private RedisClientInterface $redisClient;
 
     public function __construct(
-        private ?RedisClientInterface $redisClient = null,
+        ?RedisClientInterface $redisClient = null,
     ) {
         $this->redisClient = $redisClient ?? (getenv('REDIS_CLIENT') === 'predis' ? new PredisClient() : new RedisClient());
 


### PR DESCRIPTION
when the constructor argument is not the final value of the property, using a promoted property is generally a bad idea, as the type might not be the same.