### PR TITLE
fix: use query parameters instead of service filters

### DIFF
--- a/src/Bundle/ApiPlatform/Filters/ExactSearchFilter.php
+++ b/src/Bundle/ApiPlatform/Filters/ExactSearchFilter.php
@@ -6,7 +6,7 @@ namespace Talleu\RedisOm\Bundle\ApiPlatform\Filters;
 
 use ApiPlatform\Metadata\Parameter;
 
-class BooleanFilter extends RedisAbstractFilter
+class ExactSearchFilter extends RedisAbstractFilter
 {
     public function __invoke(array $params, Parameter $parameter = null, array $context = []): array
     {

--- a/src/Bundle/ApiPlatform/Filters/NumericFilter.php
+++ b/src/Bundle/ApiPlatform/Filters/NumericFilter.php
@@ -4,32 +4,13 @@ declare(strict_types=1);
 
 namespace Talleu\RedisOm\Bundle\ApiPlatform\Filters;
 
-use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\FilterInterface;
-use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 
 class NumericFilter extends RedisAbstractFilter
 {
-    public function apply(array $params, string $resourceClass, ?Operation $operation = null, array $context = []): array
+    public function __invoke(array $params, Parameter $parameter = null, array $context = []): array
     {
-        foreach ($context['filters'] as $property => $value) {
-            if (!property_exists($resourceClass, $property)) {
-                continue;
-            }
-
-            if (!$this->isPropertyEnabled($property, $resourceClass)) {
-                continue;
-            }
-
-            $params['criteria'][$property] = $value;
-        }
-
+        $params['criteria'][$parameter->getProperty() ?? $parameter->getKey()] = $parameter->getValue();
         return $params;
-    }
-
-
-    public function getDescription(string $resourceClass): array
-    {
-        return [];
     }
 }

--- a/src/Bundle/ApiPlatform/Filters/OrderFilter.php
+++ b/src/Bundle/ApiPlatform/Filters/OrderFilter.php
@@ -4,46 +4,35 @@ declare(strict_types=1);
 
 namespace Talleu\RedisOm\Bundle\ApiPlatform\Filters;
 
-use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\FilterInterface;
-use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 
 class OrderFilter extends RedisAbstractFilter
 {
-    public function apply(array $params, string $resourceClass, ?Operation $operation = null, array $context = []): array
+    public function __construct(private readonly array $properties = [])
     {
-        foreach ($context['filters'] as $property => $value) {
-            if ('order' !== $property) {
+    }
+
+    public function __invoke(array $params, Parameter $parameter = null, array $context = []): array
+    {
+        // todo: use constraint validations instead
+        if (!is_array($parameter->getValue())) {
+            return $params;
+        }
+
+        foreach ($parameter->getValue([]) as $prop => $value) {
+            if (!in_array($prop, $this->properties, true)) {
                 continue;
             }
 
-            if (!is_array($value)) {
+            // could also use validation constraints
+            if (!in_array(strtoupper($value), ['ASC', 'DESC'])) {
                 continue;
             }
 
-            foreach ($value as $propertyToOrder => $strategy) {
-                if (!in_array(strtoupper($strategy), ['ASC', 'DESC'])) {
-                    continue;
-                }
 
-                if (!property_exists($resourceClass, $propertyToOrder)) {
-                    continue;
-                }
-
-                if (!$this->isPropertyEnabled($propertyToOrder, $resourceClass)) {
-                    continue;
-                }
-
-                $params['orderBy'][$propertyToOrder] = strtoupper($strategy);
-            }
+            $params['orderBy'][$prop] = strtoupper($value);
         }
 
         return $params;
-    }
-
-
-    public function getDescription(string $resourceClass): array
-    {
-        return [];
     }
 }

--- a/src/Bundle/ApiPlatform/Filters/RedisAbstractFilter.php
+++ b/src/Bundle/ApiPlatform/Filters/RedisAbstractFilter.php
@@ -4,45 +4,24 @@ declare(strict_types=1);
 
 namespace Talleu\RedisOm\Bundle\ApiPlatform\Filters;
 
-use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\JsonSchemaFilterInterface;
+use ApiPlatform\Metadata\Parameter;
 
-abstract class RedisAbstractFilter implements RedisFilterInterface
+abstract class RedisAbstractFilter implements RedisFilterInterface, JsonSchemaFilterInterface
 {
-    public function __construct(protected ?array $properties = null)
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $context
+     */
+    abstract public function __invoke(array $params, Parameter $parameter = null, array $context = []): array;
+
+    public function getSchema(Parameter $parameter): array
     {
+        return ['type' => 'string'];
     }
 
-    abstract public function apply(array $params, string $resourceClass, ?Operation $operation = null, array $context = []): array;
-
-    public function isPropertyEnabled(string $property, string $resourceClass): bool
+    public function getDescription(string $resourceClass): array
     {
-        $reflectionClass = new \ReflectionClass($resourceClass);
-        $reflectionApiFilters = $reflectionClass->getAttributes(ApiFilter::class);
-        if ([] === $reflectionApiFilters) {
-            return false;
-        }
-
-        foreach ($reflectionApiFilters as $reflectionApiFilter) {
-            /** @var ApiFilter $filter */
-            $filter = $reflectionApiFilter->newInstance();
-
-            if ($filter->filterClass !== static::class) {
-                continue;
-            }
-
-            $availablePropertiesFilters = $filter->properties;
-
-            if (in_array(static::class, [OrderFilter::class, NumericFilter::class]) && in_array($property, $availablePropertiesFilters)) {
-                return true;
-            }
-
-            if (SearchFilter::class === static::class && array_key_exists($property, $availablePropertiesFilters)) {
-                $this->properties = $availablePropertiesFilters;
-                return true;
-            }
-        }
-
-        return false;
+        return [];
     }
 }

--- a/src/Bundle/ApiPlatform/Filters/RedisFilterInterface.php
+++ b/src/Bundle/ApiPlatform/Filters/RedisFilterInterface.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 namespace Talleu\RedisOm\Bundle\ApiPlatform\Filters;
 
 use ApiPlatform\Metadata\FilterInterface;
-use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 
 interface RedisFilterInterface extends FilterInterface
 {
-    public function apply(array $params, string $resourceClass, ?Operation $operation = null, array $context = []): array;
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $context
+     *
+     * @return array<string, mixed>
+     */
+    public function __invoke(array $params, Parameter $parameter = null, array $context = []): array;
 }

--- a/src/Bundle/ApiPlatform/Filters/SearchFilter.php
+++ b/src/Bundle/ApiPlatform/Filters/SearchFilter.php
@@ -4,40 +4,14 @@ declare(strict_types=1);
 
 namespace Talleu\RedisOm\Bundle\ApiPlatform\Filters;
 
-use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\FilterInterface;
-use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
 
 class SearchFilter extends RedisAbstractFilter
 {
-    public function apply(array $params, string $resourceClass, ?Operation $operation = null, array $context = []): array
+    public function __invoke(array $params, Parameter $parameter = null, array $context = []): array
     {
-        foreach ($context['filters'] as $property => $value) {
-            if ('order' === $property) {
-                continue;
-            }
-
-            if (!property_exists($resourceClass, $property)) {
-                continue;
-            }
-
-            if (!$this->isPropertyEnabled($property, $resourceClass)) {
-                continue;
-            }
-
-            $strategy = $this->properties[$property];
-            if ('partial' === $strategy) {
-                $params['search_strategy'] = 'partial';
-            }
-
-            $params['criteria'][$property] = $value;
-        }
-
+        $params['search_strategy'] = 'partial';
+        $params['criteria'][$parameter->getProperty() ?? $parameter->getKey()] = $parameter->getValue();
         return $params;
-    }
-
-    public function getDescription(string $resourceClass): array
-    {
-        return [];
     }
 }

--- a/src/Bundle/Resources/config/api_platform.xml
+++ b/src/Bundle/Resources/config/api_platform.xml
@@ -6,8 +6,6 @@
 
     <services>
         <service id="talleu_php_redis_om.api_platform.query_extension.filters" class="Talleu\RedisOm\Bundle\ApiPlatform\Extensions\FilterExtension" public="false">
-            <argument type="service" id="api_platform.filter_locator" />
-
             <tag name="talleu_php_redis_om.api_platform.query_extension.collection" priority="-64" />
         </service>
 

--- a/tests/ApiPlatform/Entity/Book.php
+++ b/tests/ApiPlatform/Entity/Book.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Talleu\RedisOm\Tests\ApiPlatform\Entity;
 
-use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\QueryParameter;
 use Talleu\RedisOm\Bundle\ApiPlatform\Filters\SearchFilter;
-use Talleu\RedisOm\Bundle\ApiPlatform\State\RedisProcessor;
-use Talleu\RedisOm\Bundle\ApiPlatform\State\RedisProvider;
 use Talleu\RedisOm\Om\Mapping as RedisOm;
 
 #[RedisOm\Entity]
@@ -17,7 +15,6 @@ use Talleu\RedisOm\Om\Mapping as RedisOm;
     paginationClientItemsPerPage: true,
     paginationPartial: true,
 )]
-#[ApiFilter(SearchFilter::class, properties: ['name' => 'partial'])]
 class Book
 {
     #[RedisOm\Id]

--- a/tests/ApiPlatform/Entity/Dummy.php
+++ b/tests/ApiPlatform/Entity/Dummy.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Talleu\RedisOm\Tests\ApiPlatform\Entity;
 
-use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Laravel\Eloquent\Filter\JsonApi\SortFilter;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\QueryParameter;
 use Talleu\RedisOm\Bundle\ApiPlatform\Filters\BooleanFilter;
+use Talleu\RedisOm\Bundle\ApiPlatform\Filters\ExactSearchFilter;
 use Talleu\RedisOm\Bundle\ApiPlatform\Filters\NumericFilter;
 use Talleu\RedisOm\Bundle\ApiPlatform\Filters\OrderFilter;
 use Talleu\RedisOm\Bundle\ApiPlatform\Filters\SearchFilter;
@@ -20,10 +22,12 @@ use Talleu\RedisOm\Tests\Fixtures\Hash\DummyHash;
     provider: RedisProvider::class,
     processor: RedisProcessor::class,
 )]
-#[ApiFilter(SearchFilter::class, properties: ['name' => 'exact', 'partialName' => 'partial'])]
-#[ApiFilter(NumericFilter::class, properties: ['age', 'price'])]
-#[ApiFilter(BooleanFilter::class, properties: ['enabled'])]
-#[ApiFilter(OrderFilter::class, properties: ['age', 'id', 'name'])]
+#[QueryParameter(key: 'name', filter: new ExactSearchFilter())]
+#[QueryParameter(key: 'partialName', filter: new SearchFilter())]
+#[QueryParameter(key: 'age', filter: new NumericFilter())]
+#[QueryParameter(key: 'price', filter: new NumericFilter())]
+#[QueryParameter(key: 'enabled', filter: new BooleanFilter())]
+#[QueryParameter(key: 'order[:property]', filter: new OrderFilter(properties: ['age', 'id', 'name']))]
 class Dummy extends DummyHash
 {
     #[RedisOm\Property(index: true)]


### PR DESCRIPTION
You could do something like this : https://github.com/api-platform/core/blob/main/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php#L92 

To add constraint validation to your query parameters when you detect a filter of a certain type (ie order filter).

Also you've an issue with the Partial search filter, it activates the partial strategy for every filters.  