### PR TITLE
feat: validate identifier indexing in generateSchema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "symfony/browser-kit": "^7.2",
     "symfony/http-client": "^7.2",
     "symfony/yaml": "^7.2",
-    "predis/predis": "^2.0 || ^3.0"
+    "predis/predis": "^2.0||^3.0"
   },
   "license": "MIT",
   "bin": ["bin/redisMigration"],

--- a/src/Client/PredisClient.php
+++ b/src/Client/PredisClient.php
@@ -420,6 +420,41 @@ final class PredisClient implements RedisClientInterface
     /**
      * @inheritdoc
      */
+    public function getIndexInfo(string $prefixKey): array
+    {
+        $result = $this->redis->executeRaw([RedisCommands::INFO_INDEX->value, Converter::prefix($prefixKey)]);
+        if ($result === false) {
+            return [];
+        }
+
+        return $this->parseIndexAttributes((array) $result);
+    }
+
+    private function parseIndexAttributes(array $rawInfo): array
+    {
+        for ($i = 0, $max = count($rawInfo) - 1; $i < $max; $i++) {
+            if ($rawInfo[$i] !== 'attributes') {
+                continue;
+            }
+
+            $attributes = [];
+            foreach ((array) $rawInfo[$i + 1] as $attrRaw) {
+                $attr = [];
+                for ($j = 0, $jMax = count($attrRaw) - 1; $j < $jMax; $j += 2) {
+                    $attr[$attrRaw[$j]] = $attrRaw[$j + 1];
+                }
+                $attributes[] = $attr;
+            }
+
+            return $attributes;
+        }
+
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function search(string $prefixKey, array $search, array $orderBy, ?string $format = RedisFormat::HASH->value, ?int $numberOfResults = null, int $offset = 0, ?string $searchType = Property::INDEX_TAG, array $rangeFilters = []): array
     {
         $arguments = [RedisCommands::SEARCH->value, Converter::prefix($prefixKey)];

--- a/src/Client/RedisClient.php
+++ b/src/Client/RedisClient.php
@@ -408,6 +408,41 @@ final class RedisClient implements RedisClientInterface
     /**
      * @inheritdoc
      */
+    public function getIndexInfo(string $prefixKey): array
+    {
+        $result = $this->redis->rawCommand(RedisCommands::INFO_INDEX->value, Converter::prefix($prefixKey));
+        if ($result === false) {
+            return [];
+        }
+
+        return $this->parseIndexAttributes((array) $result);
+    }
+
+    private function parseIndexAttributes(array $rawInfo): array
+    {
+        for ($i = 0, $max = count($rawInfo) - 1; $i < $max; $i++) {
+            if ($rawInfo[$i] !== 'attributes') {
+                continue;
+            }
+
+            $attributes = [];
+            foreach ((array) $rawInfo[$i + 1] as $attrRaw) {
+                $attr = [];
+                for ($j = 0, $jMax = count($attrRaw) - 1; $j < $jMax; $j += 2) {
+                    $attr[$attrRaw[$j]] = $attrRaw[$j + 1];
+                }
+                $attributes[] = $attr;
+            }
+
+            return $attributes;
+        }
+
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function search(string $prefixKey, array $search, array $orderBy, ?string $format = RedisFormat::HASH->value, ?int $numberOfResults = null, int $offset = 0, ?string $searchType = Property::INDEX_TAG, array $rangeFilters = []): array
     {
         $arguments = [RedisCommands::SEARCH->value, Converter::prefix($prefixKey)];

--- a/src/Client/RedisClientInterface.php
+++ b/src/Client/RedisClientInterface.php
@@ -153,4 +153,12 @@ interface RedisClientInterface
      * Discard a Redis transaction (DISCARD).
      */
     public function discard(): void;
+
+    /**
+     * Return parsed attributes from FT.INFO for the given index.
+     * Each entry has keys: identifier, attribute, type, and any extra flags.
+     *
+     * @return array<int, array<string, string>>
+     */
+    public function getIndexInfo(string $prefixKey): array;
 }

--- a/src/Client/RedisCommands.php
+++ b/src/Client/RedisCommands.php
@@ -13,4 +13,5 @@ enum RedisCommands: string
     case CREATE_INDEX = 'FT.CREATE';
     case DROP_INDEX = 'FT.DROPINDEX';
     case SEARCH = 'FT.SEARCH';
+    case INFO_INDEX = 'FT.INFO';
 }

--- a/src/Command/GenerateSchema.php
+++ b/src/Command/GenerateSchema.php
@@ -101,6 +101,11 @@ final class GenerateSchema
 
                 // Property type not supported for indexing
                 if (!in_array($propertyType, ['int', 'string', 'float', 'bool']) && !class_exists($propertyType)) {
+                    if ($reflectionProperty->getAttributes(Id::class) !== []) {
+                        throw new BadIdentifierConfigurationException(
+                            sprintf("Identifier '%s' in %s has unsupported type '%s'. Supported types: int, string, float, bool.", $propertyName, $fqcn, $propertyType)
+                        );
+                    }
                     continue;
                 }
 

--- a/tests/Console/GenerateSchemaIntegrationTest.php
+++ b/tests/Console/GenerateSchemaIntegrationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Console;
+
+use PHPUnit\Framework\TestCase;
+use Talleu\RedisOm\Client\RedisClientInterface;
+use Talleu\RedisOm\Command\GenerateSchema;
+use Talleu\RedisOm\Exception\BadIdentifierConfigurationException;
+use Talleu\RedisOm\Om\RedisObjectManager;
+use Talleu\RedisOm\Tests\Client\Client;
+use Talleu\RedisOm\Tests\Fixtures\Hash\DummyHash;
+
+class GenerateSchemaIntegrationTest extends TestCase
+{
+    private RedisClientInterface $redisClient;
+
+    protected function setUp(): void
+    {
+        $this->redisClient = (new Client())->redisClient;
+        $this->redisClient->flushAll();
+        GenerateSchema::generateSchema(__DIR__ . '/../Fixtures', $this->redisClient);
+    }
+
+    public function testIdTagIndexWorksAfterGenerateSchema(): void
+    {
+        $om = new RedisObjectManager($this->redisClient);
+        $dummy = DummyHash::create(id: 99, age: 30, price: 9.99, name: 'TagTest');
+        $om->persist($dummy);
+        $om->flush();
+
+        $count = $this->redisClient->count(DummyHash::class, ['id' => '99']);
+        $this->assertSame(1, $count, 'TAG index on id is not searchable');
+    }
+
+    public function testIdNumericIndexWorksAfterGenerateSchema(): void
+    {
+        $om = new RedisObjectManager($this->redisClient);
+        $dummy = DummyHash::create(id: 99, age: 30, price: 9.99, name: 'NumericTest');
+        $om->persist($dummy);
+        $om->flush();
+
+        // Validates the NUMERIC alias id_numeric is present in the index
+        $count = $this->redisClient->count(DummyHash::class, [], null, ['@id_numeric:[99 99]']);
+        $this->assertSame(1, $count, 'NUMERIC index on id is not searchable');
+    }
+
+    public function testFindByIdWorksAfterGenerateSchema(): void
+    {
+        $om = new RedisObjectManager($this->redisClient);
+        $dummy = DummyHash::create(id: 42, age: 30, price: 9.99, name: 'FindById');
+        $om->persist($dummy);
+        $om->flush();
+
+        $repo = $om->getRepository(DummyHash::class);
+        $results = $repo->findBy(['id' => 42]);
+
+        $this->assertCount(1, $results);
+        $this->assertSame(42, $results[0]->id);
+        $this->assertSame('FindById', $results[0]->name);
+    }
+
+    public function testUnsupportedIdTypeThrowsBadIdentifierConfigurationException(): void
+    {
+        $dir = sys_get_temp_dir() . '/redis-om-bad-id-' . getmypid();
+        @mkdir($dir);
+
+        $src = <<<'PHP'
+<?php
+namespace RedisOmTest\BadId;
+use Talleu\RedisOm\Om\Mapping as RedisOm;
+#[RedisOm\Entity]
+class DummyWithArrayId {
+    #[RedisOm\Id]
+    #[RedisOm\Property]
+    public ?array $id = null;
+    #[RedisOm\Property(index: true)]
+    public string $name = 'test';
+}
+PHP;
+        file_put_contents($dir . '/DummyWithArrayId.php', $src);
+        require_once $dir . '/DummyWithArrayId.php';
+
+        try {
+            GenerateSchema::generateSchema($dir, $this->redisClient);
+            $this->fail('Expected BadIdentifierConfigurationException was not thrown');
+        } catch (BadIdentifierConfigurationException $e) {
+            $this->assertMatchesRegularExpression("/Identifier 'id'.*unsupported type 'array'/", $e->getMessage());
+        } finally {
+            @unlink($dir . '/DummyWithArrayId.php');
+            @rmdir($dir);
+        }
+    }
+}

--- a/tests/Functionnal/Client/RedisClientIntegrationTest.php
+++ b/tests/Functionnal/Client/RedisClientIntegrationTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Functionnal\Client;
+
+use PHPUnit\Framework\TestCase;
+use Talleu\RedisOm\Client\RedisClientInterface;
+use Talleu\RedisOm\Tests\Client\Client;
+
+final class RedisClientIntegrationTest extends TestCase
+{
+    private RedisClientInterface $client;
+
+    protected function setUp(): void
+    {
+        $this->client = (new Client())->redisClient;
+        $this->client->flushAll();
+    }
+
+    // --- scanKeys ---
+
+    public function testScanKeysReturnsMatchingKeys(): void
+    {
+        $this->client->hMSet('ScanTest:1', ['id' => '1']);
+        $this->client->hMSet('ScanTest:2', ['id' => '2']);
+        $this->client->hMSet('OtherPrefix:1', ['id' => '99']);
+
+        $keys = $this->client->scanKeys('ScanTest');
+
+        $this->assertCount(2, $keys);
+        $this->assertContains('ScanTest:1', $keys);
+        $this->assertContains('ScanTest:2', $keys);
+    }
+
+    public function testScanKeysReturnsEmptyArrayWhenNoMatch(): void
+    {
+        $keys = $this->client->scanKeys('NonExistentPrefix_XYZ');
+
+        $this->assertSame([], $keys);
+    }
+
+    // --- discard ---
+
+    public function testDiscardResetsConnectionToNormalState(): void
+    {
+        $this->client->multi();
+        $this->client->discard();
+
+        $this->client->hMSet('AfterDiscard:1', ['id' => '1', 'name' => 'ok']);
+        $result = $this->client->hGetAll('AfterDiscard:1');
+
+        $this->assertSame('1', $result['id']);
+        $this->assertSame('ok', $result['name']);
+    }
+
+    public function testDiscardCancelsQueuedWrites(): void
+    {
+        $this->client->multi();
+        try {
+            $this->client->hMSet('InTx:99', ['id' => '99']);
+        } catch (\Throwable) {
+            // some clients behave differently in MULTI mode
+        }
+        $this->client->discard();
+
+        $keys = $this->client->scanKeys('InTx');
+        $this->assertCount(0, $keys);
+    }
+
+    // --- jsonGetProperty ---
+
+    public function testJsonGetPropertyReturnsSpecificField(): void
+    {
+        $this->client->jsonSet('JsonPropTest:1', '$', '{"id":"1","name":"Alice","age":30}');
+
+        $raw = $this->client->jsonGetProperty('JsonPropTest:1', 'name');
+
+        $this->assertNotNull($raw);
+        $decoded = json_decode($raw, true);
+        $this->assertSame('Alice', $decoded[0]);
+    }
+
+    public function testJsonGetPropertyReturnsNullWhenKeyMissing(): void
+    {
+        $this->assertNull($this->client->jsonGetProperty('NonExistent:99', 'name'));
+    }
+
+    public function testJsonGetPropertyReturnsEmptyForMissingField(): void
+    {
+        $this->client->jsonSet('JsonPropTest:2', '$', '{"id":"2"}');
+
+        $result = $this->client->jsonGetProperty('JsonPropTest:2', 'nonexistent_field');
+
+        if ($result !== null) {
+            $this->assertSame([], json_decode($result, true));
+        } else {
+            $this->assertNull($result);
+        }
+    }
+
+    // --- hSet / hget ---
+
+    public function testHSetAndHGetWork(): void
+    {
+        $this->client->hMSet('HSetTest:1', ['id' => '1', 'name' => 'initial']);
+        $this->client->hSet('HSetTest:1', 'name', 'updated');
+
+        $this->assertSame('updated', $this->client->hget('HSetTest:1', 'name'));
+    }
+
+    // --- jsonGet / jsonSet round-trip ---
+
+    public function testJsonSetAndGetRoundTrip(): void
+    {
+        $payload = '{"id":"42","name":"Bob"}';
+        $this->client->jsonSet('JsonRoundTrip:42', '$', $payload);
+
+        $result = $this->client->jsonGet('JsonRoundTrip:42');
+
+        $this->assertNotNull($result);
+        $decoded = json_decode($result, true);
+        $this->assertSame('42', $decoded['id']);
+        $this->assertSame('Bob', $decoded['name']);
+    }
+
+    public function testJsonGetReturnsNullForMissingKey(): void
+    {
+        $this->assertNull($this->client->jsonGet('NonExistent:99'));
+    }
+
+    // --- expireTime ---
+
+    public function testExpireAndExpireTimeRoundTrip(): void
+    {
+        $this->client->hMSet('ExpireTest:1', ['id' => '1']);
+        $this->client->expire('ExpireTest:1', 3600);
+
+        $timestamp = $this->client->expireTime('ExpireTest:1');
+
+        $this->assertGreaterThan(time(), $timestamp);
+        $this->assertLessThanOrEqual(time() + 3601, $timestamp);
+    }
+
+    public function testExpireTimeReturnsNegativeOneWhenNoTtl(): void
+    {
+        $this->client->hMSet('NoTtl:1', ['id' => '1']);
+
+        $this->assertSame(-1, $this->client->expireTime('NoTtl:1'));
+    }
+
+    // --- hGetAllMultiple ---
+
+    public function testHGetAllMultipleReturnsBatchedHashes(): void
+    {
+        $this->client->hMSet('MultiHash:1', ['id' => '1', 'name' => 'Alice']);
+        $this->client->hMSet('MultiHash:2', ['id' => '2', 'name' => 'Bob']);
+        $this->client->hMSet('MultiHash:3', ['id' => '3', 'name' => 'Charlie']);
+
+        $result = $this->client->hGetAllMultiple(['MultiHash:1', 'MultiHash:2', 'MultiHash:3']);
+
+        $this->assertCount(3, $result);
+        $this->assertSame('Alice', $result['MultiHash:1']['name']);
+        $this->assertSame('Bob', $result['MultiHash:2']['name']);
+        $this->assertSame('Charlie', $result['MultiHash:3']['name']);
+    }
+
+    public function testHGetAllMultipleSkipsMissingKeys(): void
+    {
+        $this->client->hMSet('MultiHash:1', ['id' => '1']);
+
+        $result = $this->client->hGetAllMultiple(['MultiHash:1', 'MultiHash:NonExistent']);
+
+        $this->assertArrayHasKey('MultiHash:1', $result);
+        $this->assertArrayNotHasKey('MultiHash:NonExistent', $result);
+    }
+
+    // --- jsonGetMultiple ---
+
+    public function testJsonGetMultipleReturnsBatchedDocuments(): void
+    {
+        $this->client->jsonSet('MultiJson:1', '$', '{"id":"1","name":"Alice"}');
+        $this->client->jsonSet('MultiJson:2', '$', '{"id":"2","name":"Bob"}');
+
+        $result = $this->client->jsonGetMultiple(['MultiJson:1', 'MultiJson:2']);
+
+        $this->assertCount(2, $result);
+        $this->assertStringContainsString('Alice', $result['MultiJson:1']);
+        $this->assertStringContainsString('Bob', $result['MultiJson:2']);
+    }
+
+    public function testJsonGetMultipleReturnsNullForMissingKeys(): void
+    {
+        $this->client->jsonSet('MultiJson:1', '$', '{"id":"1"}');
+
+        $result = $this->client->jsonGetMultiple(['MultiJson:1', 'MultiJson:NonExistent']);
+
+        $this->assertNotNull($result['MultiJson:1']);
+        $this->assertNull($result['MultiJson:NonExistent']);
+    }
+}

--- a/tests/Unit/Client/PredisClientTest.php
+++ b/tests/Unit/Client/PredisClientTest.php
@@ -1,0 +1,760 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Unit\Client;
+
+use PHPUnit\Framework\TestCase;
+use Predis\Client as PredisLib;
+use Predis\Pipeline\Pipeline;
+use Talleu\RedisOm\Client\PredisClient;
+use Talleu\RedisOm\Exception\RedisClientResponseException;
+use Talleu\RedisOm\Om\Mapping\Property;
+
+final class PredisClientTest extends TestCase
+{
+    private function makeClient(PredisLib $predis): PredisClient
+    {
+        return new PredisClient($predis);
+    }
+
+    private function mockPredis(): PredisLib
+    {
+        return $this->getMockBuilder(PredisLib::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['executeRaw', 'pipeline'])
+            ->addMethods([
+                'hmset', 'hset', 'hgetall', 'hget', 'del',
+                'flushall', 'expire', 'expiretime', 'keys',
+                'multi', 'exec', 'discard', 'scan',
+            ])
+            ->getMock();
+    }
+
+    private function mockPipeline(): Pipeline
+    {
+        return $this->getMockBuilder(Pipeline::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['execute'])
+            ->addMethods(['hgetall'])
+            ->getMock();
+    }
+
+    // --- hMSet ---
+
+    public function testHMSetThrowsOnRedisError(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('hmset')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->hMSet('key', ['field' => 'value']);
+    }
+
+    public function testHMSetSucceeds(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->expects($this->once())->method('hmset')->willReturn(true);
+
+        $this->makeClient($mock)->hMSet('key', ['field' => 'value']);
+    }
+
+    // --- hget ---
+
+    public function testHgetThrowsWhenResultIsNull(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('hget')->willReturn(null);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->hget('key', 'field');
+    }
+
+    public function testHgetReturnsValue(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('hget')->willReturn('hello');
+
+        $this->assertSame('hello', $this->makeClient($mock)->hget('key', 'field'));
+    }
+
+    // --- hSet ---
+
+    public function testHSetCallsPredisHSet(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->expects($this->once())->method('hset')->with('key', 'field', 'value');
+
+        $this->makeClient($mock)->hSet('key', 'field', 'value');
+    }
+
+    // --- hGetAll ---
+
+    public function testHGetAllReturnsArray(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('hgetall')->willReturn(['id' => '1', 'name' => 'test']);
+
+        $this->assertSame(['id' => '1', 'name' => 'test'], $this->makeClient($mock)->hGetAll('key'));
+    }
+
+    // --- del ---
+
+    public function testDelThrowsOnRedisError(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('del')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->del('key');
+    }
+
+    // --- jsonGet ---
+
+    public function testJsonGetReturnsNullWhenKeyNotFound(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $this->assertNull($this->makeClient($mock)->jsonGet('key'));
+    }
+
+    public function testJsonGetReturnsJsonString(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn('{"id":"1"}');
+
+        $this->assertSame('{"id":"1"}', $this->makeClient($mock)->jsonGet('key'));
+    }
+
+    // --- jsonGetProperty ---
+
+    public function testJsonGetPropertyReturnsNullWhenKeyNotFound(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $this->assertNull($this->makeClient($mock)->jsonGetProperty('key', 'field'));
+    }
+
+    public function testJsonGetPropertyReturnsValue(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn('["hello"]');
+
+        $this->assertSame('["hello"]', $this->makeClient($mock)->jsonGetProperty('key', 'field'));
+    }
+
+    // --- jsonSet ---
+
+    public function testJsonSetThrowsOnRedisError(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->jsonSet('key', '$', '{}');
+    }
+
+    // --- jsonSetProperty ---
+
+    public function testJsonSetPropertyCallsExecuteRaw(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->expects($this->once())->method('executeRaw');
+
+        $this->makeClient($mock)->jsonSetProperty('key', 'field', '"value"');
+    }
+
+    // --- jsonDel ---
+
+    public function testJsonDelThrowsOnRedisError(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->jsonDel('key');
+    }
+
+    // --- jsonMSet ---
+
+    public function testJsonMSetThrowsOnInvalidParamCount(): void
+    {
+        $mock = $this->mockPredis();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->makeClient($mock)->jsonMSet(['key', '$']); // count=2, not multiple of 3
+    }
+
+    public function testJsonMSetThrowsOnRedisError(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->jsonMSet(['key', '$', '{}']);
+    }
+
+    // --- createIndex ---
+
+    public function testCreateIndexDoesNothingWhenPropertiesEmpty(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->expects($this->never())->method('executeRaw');
+
+        $this->makeClient($mock)->createIndex('TestIndex', 'HASH', []);
+    }
+
+    public function testCreateIndexThrowsOnRedisError(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $property = (object)['name' => 'name', 'indexName' => 'name', 'indexType' => Property::INDEX_TAG];
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->createIndex('TestIndex', 'HASH', [$property]);
+    }
+
+    public function testCreateIndexHandlesTimestampProperty(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $flat = implode(' ', $args);
+            $this->assertStringContainsString('created_at#timestamp', $flat);
+            return true;
+        });
+
+        $property = (object)[
+            'name' => 'created_at#timestamp',
+            'indexName' => 'created_at#timestamp',
+            'indexType' => 'NUMERIC',
+        ];
+
+        $this->makeClient($mock)->createIndex('TestIndex', 'HASH', [$property]);
+    }
+
+    // --- dropIndex ---
+
+    public function testDropIndexReturnsFalseOnRedisException(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willThrowException(new \RedisException('ERR no such index'));
+
+        $this->assertFalse($this->makeClient($mock)->dropIndex('NonExistentIndex'));
+    }
+
+    public function testDropIndexReturnsTrueOnSuccess(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn('OK');
+
+        $this->assertTrue($this->makeClient($mock)->dropIndex('ExistingIndex'));
+    }
+
+    // --- count ---
+
+    public function testCountThrowsOnRedisError(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->count('TestIndex', ['field' => 'value']);
+    }
+
+    public function testCountReturnsZeroWhenNoResults(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([0]);
+
+        $this->assertSame(0, $this->makeClient($mock)->count('TestIndex'));
+    }
+
+    public function testCountReturnsCorrectCount(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([2, 'key1', [], 'key2', []]);
+
+        $this->assertSame(2, $this->makeClient($mock)->count('TestIndex'));
+    }
+
+    public function testCountWithTagCriteriaBuildsCorrectQuery(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $this->assertStringContainsString('@name:{Alice}', implode(' ', $args));
+            return [1, 'key1', []];
+        });
+
+        $this->makeClient($mock)->count('TestIndex', ['name' => 'Alice'], Property::INDEX_TAG);
+    }
+
+    public function testCountWithNumericSearchType(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $query = implode(' ', $args);
+            $this->assertStringContainsString('@age:30', $query);
+            $this->assertStringNotContainsString('{', $query);
+            return [1, 'key1', []];
+        });
+
+        $this->makeClient($mock)->count('TestIndex', ['age' => '30'], Property::INDEX_NUMERIC);
+    }
+
+    public function testCountEscapesDashInCriteriaValue(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $this->assertStringContainsString('\-', implode(' ', $args));
+            return [1, 'key1', []];
+        });
+
+        $this->makeClient($mock)->count('TestIndex', ['id' => '550e8400-e29b-41d4-a716-446655440000'], Property::INDEX_TAG);
+    }
+
+    public function testCountWithRangeFilters(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $this->assertStringContainsString('@price:[10 50]', implode(' ', $args));
+            return [1, 'key1', []];
+        });
+
+        $this->makeClient($mock)->count('TestIndex', [], null, ['@price:[10 50]']);
+    }
+
+    // --- scanKeys ---
+
+    public function testScanKeysReturnsKeysOnFirstIteration(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('scan')->willReturn([0, ['ScanTest:1', 'ScanTest:2']]);
+
+        $result = $this->makeClient($mock)->scanKeys('ScanTest');
+
+        $this->assertCount(2, $result);
+        $this->assertContains('ScanTest:1', $result);
+        $this->assertContains('ScanTest:2', $result);
+    }
+
+    public function testScanKeysReturnsEmptyWhenNoMatch(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('scan')->willReturn([0, []]);
+
+        $this->assertSame([], $this->makeClient($mock)->scanKeys('NonExistent'));
+    }
+
+    public function testScanKeysIteratesUntilCursorZero(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('scan')->willReturnOnConsecutiveCalls(
+            [1, ['key:1']],
+            [0, ['key:2']],
+        );
+
+        $result = $this->makeClient($mock)->scanKeys('key');
+
+        $this->assertCount(2, $result);
+        $this->assertContains('key:1', $result);
+        $this->assertContains('key:2', $result);
+    }
+
+    // --- flushAll ---
+
+    public function testFlushAllThrowsOnRedisError(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('flushall')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->flushAll();
+    }
+
+    // --- expire ---
+
+    public function testExpireThrowsOnRedisError(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('expire')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->expire('key', 3600);
+    }
+
+    // --- expireTime ---
+
+    public function testExpireTimeReturnsTimestamp(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('expiretime')->willReturn(1700000000);
+
+        $this->assertSame(1700000000, $this->makeClient($mock)->expireTime('key'));
+    }
+
+    // --- hGetAllMultiple ---
+
+    public function testHGetAllMultipleReturnsPipelineResults(): void
+    {
+        $pipeline = $this->mockPipeline();
+        $pipeline->method('execute')->willReturn([
+            ['id' => '1', 'name' => 'Alice'],
+            [],
+            ['id' => '3', 'name' => 'Charlie'],
+        ]);
+
+        $mock = $this->mockPredis();
+        $mock->method('pipeline')->willReturn($pipeline);
+
+        $result = $this->makeClient($mock)->hGetAllMultiple(['Key:1', 'Key:2', 'Key:3']);
+
+        $this->assertCount(2, $result);
+        $this->assertSame(['id' => '1', 'name' => 'Alice'], $result['Key:1']);
+        $this->assertSame(['id' => '3', 'name' => 'Charlie'], $result['Key:3']);
+        $this->assertArrayNotHasKey('Key:2', $result);
+    }
+
+    // --- jsonGetMultiple ---
+
+    public function testJsonGetMultipleReturnsPipelineResults(): void
+    {
+        $mock = $this->mockPredis();
+        // pipeline() with callback returns the results directly
+        $mock->method('pipeline')->willReturn(['{"id":"1"}', false]);
+
+        $result = $this->makeClient($mock)->jsonGetMultiple(['Key:1', 'Key:2']);
+
+        $this->assertSame('{"id":"1"}', $result['Key:1']);
+        $this->assertNull($result['Key:2']);
+    }
+
+    // --- multi / exec / discard ---
+
+    public function testMultiCallsPredisMulti(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->expects($this->once())->method('multi');
+
+        $this->makeClient($mock)->multi();
+    }
+
+    public function testExecCallsPredisExec(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->expects($this->once())->method('exec');
+
+        $this->makeClient($mock)->exec();
+    }
+
+    public function testDiscardCallsPredisDiscard(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->expects($this->once())->method('discard');
+
+        $this->makeClient($mock)->discard();
+    }
+
+    // --- keys ---
+
+    public function testKeysReturnsMatchingKeys(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('keys')->willReturn(['key:1', 'key:2']);
+
+        $this->assertSame(['key:1', 'key:2'], $this->makeClient($mock)->keys('key:*'));
+    }
+
+    // --- getIndexInfo ---
+
+    public function testGetIndexInfoReturnsEmptyArrayWhenFalse(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $this->assertSame([], $this->makeClient($mock)->getIndexInfo('TestIndex'));
+    }
+
+    public function testGetIndexInfoReturnsEmptyArrayWhenNoAttributesKey(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(['index_name', 'TestIndex', 'num_docs', '0']);
+
+        $this->assertSame([], $this->makeClient($mock)->getIndexInfo('TestIndex'));
+    }
+
+    public function testGetIndexInfoParsesAttributes(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([
+            'index_name', 'TestIndex',
+            'attributes', [
+                ['identifier', 'name', 'attribute', 'name', 'type', 'TAG'],
+            ],
+        ]);
+
+        $result = $this->makeClient($mock)->getIndexInfo('TestIndex');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('name', $result[0]['identifier']);
+        $this->assertSame('TAG', $result[0]['type']);
+    }
+
+    // --- search ---
+
+    public function testSearchThrowsOnFalseResult(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->search('TestIndex', [], [], 'HASH');
+    }
+
+    public function testSearchThrowsOnRedisException(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willThrowException(new \RedisException('ERR index not found'));
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->search('TestIndex', [], [], 'HASH');
+    }
+
+    public function testSearchReturnsEmptyWhenCountIsZero(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([0]);
+
+        $this->assertSame([], $this->makeClient($mock)->search('TestIndex', [], [], 'HASH'));
+    }
+
+    public function testSearchExtractsHashData(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([
+            1,
+            'TestIndex:1',
+            ['id', '1', 'name', 'Alice'],
+        ]);
+
+        $result = $this->makeClient($mock)->search('TestIndex', [], [], 'HASH');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('1', $result[0]['id']);
+        $this->assertSame('Alice', $result[0]['name']);
+    }
+
+    public function testSearchExtractsJsonData(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([
+            1,
+            'TestIndex:1',
+            ['$', '{"id":"1","name":"Alice"}'],
+        ]);
+
+        $result = $this->makeClient($mock)->search('TestIndex', [], [], 'JSON');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('1', $result[0]['id']);
+        $this->assertSame('Alice', $result[0]['name']);
+    }
+
+    public function testSearchWithTagCriteria(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $this->assertStringContainsString('@name:{Alice}', implode(' ', $args));
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', ['name' => 'Alice'], [], 'HASH', null, 0, Property::INDEX_TAG);
+    }
+
+    public function testSearchWithNumericCriteria(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $query = implode(' ', $args);
+            $this->assertStringContainsString('@age:30', $query);
+            $this->assertStringNotContainsString('{', $query);
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', ['age' => '30'], [], 'HASH', null, 0, Property::INDEX_NUMERIC);
+    }
+
+    public function testSearchWithOrderBy(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $flat = implode(' ', $args);
+            $this->assertStringContainsString('SORTBY', $flat);
+            $this->assertStringContainsString('ASC', $flat);
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', [], ['name' => 'ASC'], 'HASH');
+    }
+
+    public function testSearchWithLimit(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $this->assertStringContainsString('LIMIT', implode(' ', $args));
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', [], [], 'HASH', 10, 20);
+    }
+
+    public function testSearchWithRangeFilters(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $this->assertStringContainsString('@price:[10 50]', implode(' ', $args));
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', [], [], 'HASH', null, 0, null, ['@price:[10 50]']);
+    }
+
+    public function testSearchEscapesDashInCriteria(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturnCallback(function (array $args) {
+            $this->assertStringContainsString('\-', implode(' ', $args));
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', ['id' => 'abc-123'], [], 'HASH');
+    }
+
+    public function testSearchRespectsNumberOfResultsLimit(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([
+            3,
+            'TestIndex:1', ['id', '1', 'name', 'Alice'],
+            'TestIndex:2', ['id', '2', 'name', 'Bob'],
+            'TestIndex:3', ['id', '3', 'name', 'Charlie'],
+        ]);
+
+        $result = $this->makeClient($mock)->search('TestIndex', [], [], 'HASH', 2);
+
+        $this->assertCount(2, $result);
+    }
+
+    // --- customSearch ---
+
+    public function testCustomSearchThrowsOnFalseResult(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->customSearch('TestIndex', '*', 'HASH');
+    }
+
+    public function testCustomSearchThrowsOnRedisException(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willThrowException(new \RedisException('ERR'));
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->customSearch('TestIndex', '*', 'HASH');
+    }
+
+    public function testCustomSearchReturnsEmptyWhenCountIsZero(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([0]);
+
+        $this->assertSame([], $this->makeClient($mock)->customSearch('TestIndex', '*', 'HASH'));
+    }
+
+    public function testCustomSearchExtractsHashData(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([
+            1,
+            'TestIndex:1',
+            ['id', '1', 'name', 'Bob'],
+        ]);
+
+        $result = $this->makeClient($mock)->customSearch('TestIndex', '@name:{Bob}', 'HASH');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Bob', $result[0]['name']);
+    }
+
+    // --- searchLike ---
+
+    public function testSearchLikeThrowsOnFalseResult(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->searchLike('TestIndex', 'Alice', 'HASH');
+    }
+
+    public function testSearchLikeThrowsOnRedisException(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willThrowException(new \RedisException('ERR'));
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->searchLike('TestIndex', 'Alice', 'HASH');
+    }
+
+    public function testSearchLikeReturnsEmptyWhenCountIsZero(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([0]);
+
+        $this->assertSame([], $this->makeClient($mock)->searchLike('TestIndex', 'Alice', 'HASH'));
+    }
+
+    public function testSearchLikeExtractsHashData(): void
+    {
+        $mock = $this->mockPredis();
+        $mock->method('executeRaw')->willReturn([
+            1,
+            'TestIndex:1',
+            ['id', '1', 'name', 'Alice'],
+        ]);
+
+        $result = $this->makeClient($mock)->searchLike('TestIndex', 'Alice', 'HASH');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Alice', $result[0]['name']);
+    }
+
+    public function testSearchLikeThrowsWhenResultIsNotArray(): void
+    {
+        $mock = $this->mockPredis();
+        // Non-false, non-array response triggers the extra guard branch
+        $mock->method('executeRaw')->willReturn('unexpected_string');
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->searchLike('TestIndex', 'Alice', 'HASH');
+    }
+
+    public function testGetLastErrorCatchesExceptionFromExecuteRaw(): void
+    {
+        $mock = $this->mockPredis();
+        // Main call (hMSet) returns false → triggers handleError → calls getLastError
+        // getLastError calls executeRaw(['INVALID_COMMAND']) → throws → catch block hit
+        $mock->method('hmset')->willReturn(false);
+        $mock->method('executeRaw')->willReturnCallback(function (array $args): mixed {
+            throw new \Exception('ERR unknown command \'' . $args[0] . '\'');
+        });
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->expectExceptionMessageMatches('/ERR unknown command/');
+        $this->makeClient($mock)->hMSet('key', ['field' => 'value']);
+    }
+}

--- a/tests/Unit/Client/RedisClientTest.php
+++ b/tests/Unit/Client/RedisClientTest.php
@@ -1,0 +1,751 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Unit\Client;
+
+use PHPUnit\Framework\TestCase;
+use Talleu\RedisOm\Client\RedisClient;
+use Talleu\RedisOm\Exception\RedisClientResponseException;
+use Talleu\RedisOm\Om\Mapping\Property;
+
+final class RedisClientTest extends TestCase
+{
+    private function makeClient(\Redis $redis): RedisClient
+    {
+        return new RedisClient($redis);
+    }
+
+    private function mockRedis(): \Redis
+    {
+        $mock = $this->createMock(\Redis::class);
+        $mock->method('getLastError')->willReturn('ERR test error');
+
+        return $mock;
+    }
+
+    // --- hMSet ---
+
+    public function testHMSetThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('hMSet')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->hMSet('key', ['field' => 'value']);
+    }
+
+    public function testHMSetSucceeds(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->expects($this->once())->method('hMSet')->willReturn(true);
+
+        $this->makeClient($mock)->hMSet('key', ['field' => 'value']);
+    }
+
+    // --- hget ---
+
+    public function testHgetThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('hget')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->hget('key', 'field');
+    }
+
+    public function testHgetReturnsValue(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('hget')->willReturn('hello');
+
+        $this->assertSame('hello', $this->makeClient($mock)->hget('key', 'field'));
+    }
+
+    // --- hSet ---
+
+    public function testHSetCallsRedisHSet(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->expects($this->once())->method('hSet')->with('key', 'field', 'value');
+
+        $this->makeClient($mock)->hSet('key', 'field', 'value');
+    }
+
+    // --- hGetAll ---
+
+    public function testHGetAllThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('hGetAll')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->hGetAll('key');
+    }
+
+    public function testHGetAllReturnsArray(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('hGetAll')->willReturn(['id' => '1', 'name' => 'test']);
+
+        $this->assertSame(['id' => '1', 'name' => 'test'], $this->makeClient($mock)->hGetAll('key'));
+    }
+
+    // --- del ---
+
+    public function testDelThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('del')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->del('key');
+    }
+
+    // --- jsonGet ---
+
+    public function testJsonGetReturnsNullWhenKeyNotFound(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $this->assertNull($this->makeClient($mock)->jsonGet('key'));
+    }
+
+    public function testJsonGetReturnsJsonString(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn('{"id":"1"}');
+
+        $this->assertSame('{"id":"1"}', $this->makeClient($mock)->jsonGet('key'));
+    }
+
+    // --- jsonGetProperty ---
+
+    public function testJsonGetPropertyReturnsNullWhenKeyNotFound(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $this->assertNull($this->makeClient($mock)->jsonGetProperty('key', 'field'));
+    }
+
+    public function testJsonGetPropertyReturnsValue(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn('["hello"]');
+
+        $this->assertSame('["hello"]', $this->makeClient($mock)->jsonGetProperty('key', 'field'));
+    }
+
+    // --- jsonSet ---
+
+    public function testJsonSetThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->jsonSet('key', '$', '{}');
+    }
+
+    // --- jsonDel ---
+
+    public function testJsonDelThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->jsonDel('key');
+    }
+
+    // --- jsonMSet ---
+
+    public function testJsonMSetThrowsOnInvalidParamCount(): void
+    {
+        $mock = $this->mockRedis();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->makeClient($mock)->jsonMSet(['key', '$']); // count=2, not multiple of 3
+    }
+
+    public function testJsonMSetThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->jsonMSet(['key', '$', '{}']);
+    }
+
+    // --- createIndex ---
+
+    public function testCreateIndexDoesNothingWhenPropertiesEmpty(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->expects($this->never())->method('rawCommand');
+
+        $this->makeClient($mock)->createIndex('TestIndex', 'HASH', []);
+    }
+
+    public function testCreateIndexThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $property = (object)['name' => 'name', 'indexName' => 'name', 'indexType' => Property::INDEX_TAG];
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->createIndex('TestIndex', 'HASH', [$property]);
+    }
+
+    // --- dropIndex ---
+
+    public function testDropIndexReturnsFalseOnRedisException(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willThrowException(new \RedisException('ERR no such index'));
+
+        $this->assertFalse($this->makeClient($mock)->dropIndex('NonExistentIndex'));
+    }
+
+    public function testDropIndexReturnsTrueOnSuccess(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn('OK');
+
+        $this->assertTrue($this->makeClient($mock)->dropIndex('ExistingIndex'));
+    }
+
+    // --- count ---
+
+    public function testCountThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->count('TestIndex', ['field' => 'value']);
+    }
+
+    public function testCountReturnsZeroWhenNoResults(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([0]);
+
+        $this->assertSame(0, $this->makeClient($mock)->count('TestIndex'));
+    }
+
+    public function testCountReturnsCorrectCount(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([2, 'key1', [], 'key2', []]);
+
+        $this->assertSame(2, $this->makeClient($mock)->count('TestIndex'));
+    }
+
+    public function testCountWithTagCriteriaBuildsCorrectQuery(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $query = $args[2] ?? '';
+            $this->assertStringContainsString('@name:{Alice}', $query);
+            return [1, 'key1', []];
+        });
+
+        $this->makeClient($mock)->count('TestIndex', ['name' => 'Alice'], Property::INDEX_TAG);
+    }
+
+    public function testCountWithNumericSearchType(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $query = $args[2] ?? '';
+            $this->assertStringContainsString('@age:30', $query);
+            $this->assertStringNotContainsString('{', $query);
+            return [1, 'key1', []];
+        });
+
+        $this->makeClient($mock)->count('TestIndex', ['age' => '30'], Property::INDEX_NUMERIC);
+    }
+
+    public function testCountWithRangeFilters(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $query = $args[2] ?? '';
+            $this->assertStringContainsString('@price:[10 20]', $query);
+            return [1, 'key1', []];
+        });
+
+        $this->makeClient($mock)->count('TestIndex', [], null, ['@price:[10 20]']);
+    }
+
+    // --- scanKeys ---
+
+    public function testScanKeysReturnsEmptyWhenScanReturnsFalse(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('scan')->willReturn(false);
+
+        $this->assertSame([], $this->makeClient($mock)->scanKeys('TestPrefix'));
+    }
+
+    public function testScanKeysReturnsAllFoundKeys(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('scan')
+            ->willReturnCallback(function (&$iterator, string $pattern): array {
+                $iterator = 0;
+                return ['TestPrefix:1', 'TestPrefix:2'];
+            });
+
+        $result = $this->makeClient($mock)->scanKeys('TestPrefix');
+
+        $this->assertCount(2, $result);
+        $this->assertContains('TestPrefix:1', $result);
+        $this->assertContains('TestPrefix:2', $result);
+    }
+
+    // --- flushAll ---
+
+    public function testFlushAllThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('flushAll')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->flushAll();
+    }
+
+    // --- expire ---
+
+    public function testExpireThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('expire')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->expire('key', 3600);
+    }
+
+    // --- expireTime ---
+
+    public function testExpireTimeThrowsOnRedisError(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('expireTime')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->expireTime('key');
+    }
+
+    public function testExpireTimeReturnsTimestamp(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('expireTime')->willReturn(1700000000);
+
+        $this->assertSame(1700000000, $this->makeClient($mock)->expireTime('key'));
+    }
+
+    // --- hGetAllMultiple ---
+
+    public function testHGetAllMultipleReturnsPipelineResults(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('pipeline')->willReturn($mock);
+        $mock->method('exec')->willReturn([
+            ['id' => '1', 'name' => 'Alice'],
+            [],
+            ['id' => '3', 'name' => 'Charlie'],
+        ]);
+
+        $result = $this->makeClient($mock)->hGetAllMultiple(['Key:1', 'Key:2', 'Key:3']);
+
+        $this->assertCount(2, $result);
+        $this->assertSame(['id' => '1', 'name' => 'Alice'], $result['Key:1']);
+        $this->assertSame(['id' => '3', 'name' => 'Charlie'], $result['Key:3']);
+        $this->assertArrayNotHasKey('Key:2', $result);
+    }
+
+    // --- jsonGetMultiple ---
+
+    public function testJsonGetMultipleReturnsPipelineResults(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('pipeline')->willReturn($mock);
+        $mock->method('exec')->willReturn([
+            '{"id":"1"}',
+            false,
+        ]);
+
+        $result = $this->makeClient($mock)->jsonGetMultiple(['Key:1', 'Key:2']);
+
+        $this->assertSame('{"id":"1"}', $result['Key:1']);
+        $this->assertNull($result['Key:2']);
+    }
+
+    // --- multi / exec / discard ---
+
+    public function testMultiCallsRedisMulti(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->expects($this->once())->method('multi');
+
+        $this->makeClient($mock)->multi();
+    }
+
+    public function testExecCallsRedisExec(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->expects($this->once())->method('exec');
+
+        $this->makeClient($mock)->exec();
+    }
+
+    public function testDiscardCallsRedisDiscard(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->expects($this->once())->method('discard');
+
+        $this->makeClient($mock)->discard();
+    }
+
+    // --- keys ---
+
+    public function testKeysReturnsMatchingKeys(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('keys')->willReturn(['key:1', 'key:2']);
+
+        $this->assertSame(['key:1', 'key:2'], $this->makeClient($mock)->keys('key:*'));
+    }
+
+    // --- getIndexInfo ---
+
+    public function testGetIndexInfoReturnsEmptyArrayWhenFalse(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $this->assertSame([], $this->makeClient($mock)->getIndexInfo('TestIndex'));
+    }
+
+    public function testGetIndexInfoReturnsEmptyArrayWhenNoAttributesKey(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(['index_name', 'TestIndex', 'num_docs', '0']);
+
+        $this->assertSame([], $this->makeClient($mock)->getIndexInfo('TestIndex'));
+    }
+
+    public function testGetIndexInfoParsesAttributes(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([
+            'index_name', 'TestIndex',
+            'attributes', [
+                ['identifier', 'name', 'attribute', 'name', 'type', 'TAG'],
+            ],
+        ]);
+
+        $result = $this->makeClient($mock)->getIndexInfo('TestIndex');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('name', $result[0]['identifier']);
+        $this->assertSame('TAG', $result[0]['type']);
+    }
+
+    // --- search ---
+
+    public function testSearchThrowsOnFalseResult(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->search('TestIndex', [], [], 'HASH');
+    }
+
+    public function testSearchThrowsOnRedisException(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willThrowException(new \RedisException('ERR index not found'));
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->search('TestIndex', [], [], 'HASH');
+    }
+
+    public function testSearchReturnsEmptyWhenCountIsZero(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([0]);
+
+        $result = $this->makeClient($mock)->search('TestIndex', [], [], 'HASH');
+
+        $this->assertSame([], $result);
+    }
+
+    public function testSearchExtractsHashData(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([
+            1,
+            'TestIndex:1',
+            ['id', '1', 'name', 'Alice'],
+        ]);
+
+        $result = $this->makeClient($mock)->search('TestIndex', [], [], 'HASH');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('1', $result[0]['id']);
+        $this->assertSame('Alice', $result[0]['name']);
+    }
+
+    public function testSearchExtractsJsonData(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([
+            1,
+            'TestIndex:1',
+            ['$', '{"id":"1","name":"Alice"}'],
+        ]);
+
+        $result = $this->makeClient($mock)->search('TestIndex', [], [], 'JSON');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('1', $result[0]['id']);
+        $this->assertSame('Alice', $result[0]['name']);
+    }
+
+    // --- customSearch ---
+
+    public function testCustomSearchThrowsOnFalseResult(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->customSearch('TestIndex', '*', 'HASH');
+    }
+
+    public function testCustomSearchReturnsEmptyWhenCountIsZero(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([0]);
+
+        $this->assertSame([], $this->makeClient($mock)->customSearch('TestIndex', '*', 'HASH'));
+    }
+
+    public function testCustomSearchExtractsHashData(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([
+            1,
+            'TestIndex:1',
+            ['id', '1', 'name', 'Bob'],
+        ]);
+
+        $result = $this->makeClient($mock)->customSearch('TestIndex', '@name:{Bob}', 'HASH');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Bob', $result[0]['name']);
+    }
+
+    // --- searchLike ---
+
+    public function testSearchLikeThrowsOnFalseResult(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn(false);
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->searchLike('TestIndex', 'Alice', 'HASH');
+    }
+
+    public function testSearchLikeThrowsOnRedisException(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willThrowException(new \RedisException('ERR index not found'));
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->searchLike('TestIndex', 'Alice', 'HASH');
+    }
+
+    public function testSearchLikeReturnsEmptyWhenCountIsZero(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([0]);
+
+        $this->assertSame([], $this->makeClient($mock)->searchLike('TestIndex', 'Alice', 'HASH'));
+    }
+
+    public function testSearchLikeExtractsHashData(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([
+            1,
+            'TestIndex:1',
+            ['id', '1', 'name', 'Alice'],
+        ]);
+
+        $result = $this->makeClient($mock)->searchLike('TestIndex', 'Alice', 'HASH');
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Alice', $result[0]['name']);
+    }
+
+    // --- customSearch RedisException ---
+
+    public function testCustomSearchThrowsOnRedisException(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willThrowException(new \RedisException('ERR index not found'));
+
+        $this->expectException(RedisClientResponseException::class);
+        $this->makeClient($mock)->customSearch('TestIndex', '*', 'HASH');
+    }
+
+    // --- jsonSetProperty ---
+
+    public function testJsonSetPropertyCallsRawCommand(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->expects($this->once())->method('rawCommand');
+
+        $this->makeClient($mock)->jsonSetProperty('key', 'field', '"value"');
+    }
+
+    // --- createIndex #timestamp branch ---
+
+    public function testCreateIndexHandlesTimestampProperty(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $schema = implode(' ', $args);
+            $this->assertStringContainsString('created_at#timestamp', $schema);
+            $this->assertStringContainsString('SORTABLE', $schema);
+            return true;
+        });
+
+        $property = (object)[
+            'name' => 'created_at#timestamp',
+            'indexName' => 'created_at#timestamp',
+            'indexType' => 'NUMERIC',
+        ];
+
+        $this->makeClient($mock)->createIndex('TestIndex', 'HASH', [$property]);
+    }
+
+    // --- count: criteria with dash (UUID-like escape) ---
+
+    public function testCountEscapesDashInCriteriaValue(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $query = $args[2] ?? '';
+            $this->assertStringContainsString('\-', $query);
+            $this->assertStringNotContainsString('550e8400-e29b', $query);
+            return [1, 'key1', []];
+        });
+
+        $this->makeClient($mock)->count('TestIndex', ['id' => '550e8400-e29b-41d4-a716-446655440000'], Property::INDEX_TAG);
+    }
+
+    // --- search: full branch coverage ---
+
+    public function testSearchWithTagCriteria(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $query = $args[2] ?? '';
+            $this->assertStringContainsString('@name:{Alice}', $query);
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', ['name' => 'Alice'], [], 'HASH', null, 0, Property::INDEX_TAG);
+    }
+
+    public function testSearchWithNumericCriteria(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $query = $args[2] ?? '';
+            $this->assertStringContainsString('@age:30', $query);
+            $this->assertStringNotContainsString('{', $query);
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', ['age' => '30'], [], 'HASH', null, 0, Property::INDEX_NUMERIC);
+    }
+
+    public function testSearchWithOrderBy(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $flat = implode(' ', $args);
+            $this->assertStringContainsString('SORTBY', $flat);
+            $this->assertStringContainsString('name', $flat);
+            $this->assertStringContainsString('ASC', $flat);
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', [], ['name' => 'ASC'], 'HASH');
+    }
+
+    public function testSearchWithLimit(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $flat = implode(' ', $args);
+            $this->assertStringContainsString('LIMIT', $flat);
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', [], [], 'HASH', 10, 20);
+    }
+
+    public function testSearchWithRangeFilters(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $query = $args[2] ?? '';
+            $this->assertStringContainsString('@price:[10 50]', $query);
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', [], [], 'HASH', null, 0, null, ['@price:[10 50]']);
+    }
+
+    public function testSearchEscapesDashInCriteria(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturnCallback(function (...$args) {
+            $query = $args[2] ?? '';
+            $this->assertStringContainsString('\-', $query);
+            return [0];
+        });
+
+        $this->makeClient($mock)->search('TestIndex', ['id' => 'abc-123'], [], 'HASH');
+    }
+
+    // --- extractRedisData: numberOfResults limit ---
+
+    public function testSearchRespectsNumberOfResultsLimit(): void
+    {
+        $mock = $this->mockRedis();
+        $mock->method('rawCommand')->willReturn([
+            3,
+            'TestIndex:1', ['id', '1', 'name', 'Alice'],
+            'TestIndex:2', ['id', '2', 'name', 'Bob'],
+            'TestIndex:3', ['id', '3', 'name', 'Charlie'],
+        ]);
+
+        $result = $this->makeClient($mock)->search('TestIndex', [], [], 'HASH', 2);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('Alice', $result[0]['name']);
+        $this->assertSame('Bob', $result[1]['name']);
+    }
+}


### PR DESCRIPTION
Ref: [Always index ID](https://github.com/clementtalleu/php-redis-om/issues/104)
Ref: [Add tests](https://github.com/clementtalleu/php-redis-om/issues/79)

Throw BadIdentifierConfigurationException when an #[Id] property has a type that cannot be indexed (array, resource, etc.) instead of silently skipping it.

Add FT.INFO support via getIndexInfo() on RedisClientInterface and both client implementations. Add integration tests that verify TAG and NUMERIC indexes on the identifier are searchable after generateSchema runs.

RedisClient: 64 unit tests covering all methods, error paths, criteria building
  (TAG/NUMERIC/rangeFilters), pipeline, search/customSearch/searchLike branches,
  dash-escaping, numberOfResults limit, getIndexInfo parsing

PredisClient: 65 unit tests mirroring RedisClient coverage, adapted for Predis
  internals (executeRaw, __call dispatch, cursor-based scanKeys, searchLike non-array guard)

Integration: 16 tests against real Redis for scanKeys, discard, jsonGetProperty,
  hSet/hget, jsonSet/jsonGet, expire/expireTime, hGetAllMultiple, jsonGetMultiple

Install predis/predis ^2.0||^3.0 as dev dependency (was declared but missing from lock)