### PR TITLE
fix(RedisProcessor): use merge() for PUT/PATCH to preserve unchanged …

### DIFF
--- a/src/ApiPlatform/State/RedisProcessor.php
+++ b/src/ApiPlatform/State/RedisProcessor.php
@@ -6,6 +6,7 @@ namespace Talleu\RedisOm\ApiPlatform\State;
 
 use ApiPlatform\Metadata\DeleteOperationInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
 use Talleu\RedisOm\Om\RedisObjectManagerInterface;
 
@@ -28,7 +29,12 @@ final class RedisProcessor implements ProcessorInterface
             return null;
         }
 
-        $this->redisObjectManager->persist($data);
+        if ($operation instanceof Post) {
+            $this->redisObjectManager->persist($data);
+        } else {
+            $this->redisObjectManager->merge($data);
+        }
+
         $this->redisObjectManager->flush();
 
         return $data;

--- a/tests/Unit/ApiPlatform/State/RedisProcessorTest.php
+++ b/tests/Unit/ApiPlatform/State/RedisProcessorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Unit\ApiPlatform\State;
+
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use PHPUnit\Framework\TestCase;
+use Talleu\RedisOm\ApiPlatform\State\RedisProcessor;
+use Talleu\RedisOm\Om\RedisObjectManagerInterface;
+
+final class RedisProcessorTest extends TestCase
+{
+    private RedisObjectManagerInterface $om;
+    private RedisProcessor $processor;
+
+    protected function setUp(): void
+    {
+        $this->om = $this->createMock(RedisObjectManagerInterface::class);
+        $this->processor = new RedisProcessor($this->om);
+    }
+
+    public function testPostCallsPersist(): void
+    {
+        $data = new \stdClass();
+
+        $this->om->expects($this->once())->method('persist')->with($data);
+        $this->om->expects($this->never())->method('merge');
+        $this->om->expects($this->once())->method('flush');
+
+        $result = $this->processor->process($data, new Post());
+
+        $this->assertSame($data, $result);
+    }
+
+    public function testPatchCallsMerge(): void
+    {
+        $data = new \stdClass();
+
+        $this->om->expects($this->once())->method('merge')->with($data);
+        $this->om->expects($this->never())->method('persist');
+        $this->om->expects($this->once())->method('flush');
+
+        $result = $this->processor->process($data, new Patch());
+
+        $this->assertSame($data, $result);
+    }
+
+    public function testPutCallsMerge(): void
+    {
+        $data = new \stdClass();
+
+        $this->om->expects($this->once())->method('merge')->with($data);
+        $this->om->expects($this->never())->method('persist');
+        $this->om->expects($this->once())->method('flush');
+
+        $result = $this->processor->process($data, new Put());
+
+        $this->assertSame($data, $result);
+    }
+
+    public function testDeleteCallsRemove(): void
+    {
+        $data = new \stdClass();
+
+        $this->om->expects($this->once())->method('remove')->with($data);
+        $this->om->expects($this->never())->method('persist');
+        $this->om->expects($this->never())->method('merge');
+        $this->om->expects($this->once())->method('flush');
+
+        $result = $this->processor->process($data, new Delete());
+
+        $this->assertNull($result);
+    }
+
+    public function testNonObjectDataReturnsEarlyWithNoManagerCalls(): void
+    {
+        $this->om->expects($this->never())->method('persist');
+        $this->om->expects($this->never())->method('merge');
+        $this->om->expects($this->never())->method('remove');
+        $this->om->expects($this->never())->method('flush');
+
+        $result = $this->processor->process('not-an-object', new Post());
+
+        $this->assertSame('not-an-object', $result);
+    }
+}


### PR DESCRIPTION
Ref: https://github.com/clementtalleu/php-redis-om/issues/30

fix(RedisProcessor): use merge() for PUT/PATCH to preserve unchanged fields

POST creates a new object: persist(). PUT and PATCH update an already-loaded object that has a snapshot: merge() computes the diff and only writes changed fields. Using persist() on update operations overwrote snapshot-tracked state and bypassed the dirty-tracking mechanism.

Adds unit tests covering POST→persist, PUT→merge, PATCH→merge, DELETE→remove, and non-object early return.