### PR TITLE
docs: fix outdated and missing documentation

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -19,8 +19,12 @@ $objectManager->clear();
 // Will remove the object from Redis on flush
 $objectManager->remove($user); 
 
-// Will refresh the object from the redis state
+// Will refresh the object from the redis state (updates the object in place)
 $objectManager->refresh($user);
+
+// Will merge the object: only persist properties that changed since the last find()
+// Falls back to a full persist if the object was not loaded via find()
+$objectManager->merge($user);
 
 // Check if the object is managed by the object manager
 $objectManager->contains($user); 
@@ -69,6 +73,30 @@ $userRepository->count(['name' => 'John']);
 // Will retrieve only the property "name" of the object for the id 3.
 $userRepository->getPropertyValue(identifier: 3, property: 'name'); 
 // ⚠️ Warning: this method cannot retrieve array or nested objects when HASH format
+
+// Will retrieve multiple objects by their identifiers in a single pipeline round-trip
+$userRepository->findMultiple([1, 2, 3]);
+
+// Will retrieve all users whose name starts with 'Jo'
+$userRepository->findByStartWith(['name' => 'Jo']);
+
+// Will retrieve all users whose name ends with 'Doe'
+$userRepository->findByEndWith(['name' => 'Doe']);
+
+// Will count all users whose name contains 'John'
+$userRepository->countByLike(['name' => 'John']);
+
+// Will paginate results: returns a Paginator with items and total count
+$paginator = $userRepository->paginate(criteria: ['name' => 'John'], page: 1, itemsPerPage: 20);
+
+// Will retrieve users within 10km of a given geographic point
+$userRepository->findByGeoRadius(
+    geoField: 'location',
+    longitude: 2.3522,
+    latitude: 48.8566,
+    radius: 10,
+    unit: 'km'
+);
 ```
 
 #### You can also request objects or collection by nested objects properties

--- a/docs/api_platform.md
+++ b/docs/api_platform.md
@@ -48,6 +48,9 @@ SearchFilter
 NumericFilter
 BooleanFilter
 OrderFilter
+RangeFilter
+DateFilter
+ExistsFilter
 ```
 
 Implement them as follows:
@@ -56,7 +59,6 @@ Implement them as follows:
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\QueryParameter;
-use Talleu\RedisOm\ApiPlatform\Filters\ExactSearchFilter;
 use Talleu\RedisOm\ApiPlatform\Filters\BooleanFilter;
 use Talleu\RedisOm\ApiPlatform\Filters\NumericFilter;
 use Talleu\RedisOm\ApiPlatform\Filters\OrderFilter;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ For others PHP applications
 ```php
 // Set the persistent connection to true
 $objectManager = new RedisObjectManager();
-$bjectManager->getRedisClient()->createPersistentConnection();
+$objectManager->getRedisClient()->createPersistentConnection();
 
 // Then you can use the ObjectManager normally
 $objectManager->persist($user);

--- a/docs/events.md
+++ b/docs/events.md
@@ -8,6 +8,7 @@ Here is an example without Symfony
 
 use Talleu\RedisOm\Event\EventManager;
 use Talleu\RedisOm\Event\Events;
+use Talleu\RedisOm\Event\LifecycleEventArgs;
 use Talleu\RedisOm\Om\RedisObjectManager;
 
 $eventManager = new EventManager();

--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -16,7 +16,6 @@ use Talleu\RedisOm\Om\RedisFormat;
         format: RedisFormat::JSON->value,
         converter: new MyCustomConverter(),
         repository: new MyCustomRepository(),
-        redisClient: new MyCustomRedisClient(),
         ttl: 3600
 )]
 class User
@@ -54,13 +53,6 @@ Each of these parameters are optional and can be omitted. Here is a description 
     - Default: `null`
     - Type: `RepositoryInterface`
     - Note: The repository must implement the `RepositoryInterface` interface.
-- redisClient: 
-    - The redis client to use to connect to your Redis server. If not set, the default redis client will be used.
-    - Example: `new MyCustomRedisClient()`
-    - Default: `null`
-    - Type: `RedisClientInterface`
-    - Note: The redis client must implement the `RedisClientInterface` interface, it could be a php-redis client 
-or any other client that implements the interface.
 
 You could alternate from JSON format to HASH format in each entity by setting the format parameter to `RedisFormat::HASH->value` or `RedisFormat::JSON->value`.
 But be careful, if you switch the format in an entity that already has data stored in Redis, you will lose all the index stored in the previous format.
@@ -97,19 +89,13 @@ class User
     )]
     public string $name;
 
-    #[RedisOm\Property(
-        index: ['age_numeric' => Property::INDEX_NUMERIC, 'age_text' => Property::INDEX_TEXT],
-    )]
+    #[RedisOm\Property(index: ['age_numeric' => Property::INDEX_NUMERIC, 'age_text' => Property::INDEX_TEXT])]
     public int $age;
     
     #[RedisOm\Property]
     public ?string $description;
 
-    #[
-        RedisOm\Property(
-            index: ['createdAt#timestamp' => RedisOm\Property::INDEX_NUMERIC],
-        )
-    ]
+    #[RedisOm\Property(index: ['createdAt#timestamp' => RedisOm\Property::INDEX_NUMERIC])]
     private ?DateTimeInterface $createdAt = null;
 }
 ```
@@ -118,7 +104,10 @@ Each of these parameters are optional and can be omitted. Here is a description 
 
 - index:
     - The index in Redis. If not set, the property is false by default and could not be queryable.
-    - Example: `true` Will create default index (TAG + TEXT)
+    - Example: `true` Creates default indexes depending on the property type:
+        - `string` / object : TAG + TEXT
+        - `int` / `float` : TAG + NUMERIC
+        - `DateTime` : TAG + TEXT + NUMERIC
     - Example: `['age' => Property::INDEX_NUMERIC]`
     - Default: `false`
     - Type: `boolean | array`


### PR DESCRIPTION
Ref: https://github.com/clementtalleu/php-redis-om/issues/140

Corrections:
- mapping.md: remove non-existent `redisClient` parameter from #[Entity] attribute; fix `index: true` description to document type-dependent behavior (string/object: TAG+TEXT, int/float: TAG+NUMERIC, DateTime: TAG+TEXT+NUMERIC)
- api_platform.md: remove import of non-existent ExactSearchFilter class; add RangeFilter, DateFilter, ExistsFilter to the filter list
- configuration.md: fix typo $bjectManager -> $objectManager
- events.md: add missing `use Talleu\RedisOm\Event\LifecycleEventArgs` import in the non-Symfony example

Additions:
- advanced_usage.md: document merge(), findMultiple(), findByStartWith(), findByEndWith(), countByLike(), paginate(), findByGeoRadius()