### PR TITLE
feat(unique): add #[Unique] attribute for single-field and composite unique constraints

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -33,6 +33,23 @@ $objectManager->contains($user);
 $objectManager->getExpirationTime($user); 
 ```
 
+### Handling unique constraint violations
+
+If any entity has a `#[Unique]` constraint, `flush()` may throw `UniqueConstraintViolationException`. Wrap it where needed:
+
+```php
+use Talleu\RedisOm\Exception\UniqueConstraintViolationException;
+
+try {
+    $objectManager->persist($user);
+    $objectManager->flush();
+} catch (UniqueConstraintViolationException $e) {
+    // $e->getMessage() describes which field(s) and value(s) conflicted
+}
+```
+
+See [mapping.md](mapping.md#unique-constraints) for the full reference: composite constraints, merge/remove behavior, concurrency guarantees, and limitations.
+
 You can also retrieve and query your objects with the ObjectManager or a given repository
 ```php
 $objectManager = new RedisObjectManager(); // For Symfony users directly inject RedisObjectManagerInterface in your constructor

--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -124,6 +124,139 @@ Each of these parameters are optional and can be omitted. Here is a description 
 
 The #[RedisOm\Id] attribute is by default indexed and could be requested.
 
+## Unique constraints
+
+`#[Unique]` guarantees that no two objects of the same class share the same value for a given field (or combination of fields) at the time of `flush()`.
+
+### Single-field constraint
+
+Place `#[RedisOm\Unique]` on a property alongside `#[RedisOm\Property]`:
+
+```php
+<?php
+
+use Talleu\RedisOm\Om\Mapping as RedisOm;
+
+#[RedisOm\Entity]
+class User
+{
+    #[RedisOm\Id]
+    #[RedisOm\Property]
+    public int $id;
+
+    #[RedisOm\Property(index: true)]
+    #[RedisOm\Unique]
+    public string $email;
+
+    #[RedisOm\Property]
+    public string $name;
+}
+```
+
+Attempting to persist two objects with the same email throws on `flush()`:
+
+```php
+use Talleu\RedisOm\Exception\UniqueConstraintViolationException;
+
+$alice = new User(); $alice->id = 1; $alice->email = 'alice@example.com';
+$bob   = new User(); $bob->id   = 2; $bob->email   = 'alice@example.com'; // duplicate
+
+$objectManager->persist($alice);
+$objectManager->persist($bob);
+
+try {
+    $objectManager->flush();
+} catch (UniqueConstraintViolationException $e) {
+    echo $e->getMessage();
+    // Unique constraint violation on App\Entity\User::email, value "alice@example.com" already exists.
+}
+```
+
+### Composite constraint
+
+Place `#[RedisOm\Unique(properties: [...])]` at the **class level** to enforce uniqueness on a combination of fields.
+The attribute is repeatable, so multiple independent constraints can be declared on the same class.
+
+```php
+<?php
+
+use Talleu\RedisOm\Om\Mapping as RedisOm;
+
+#[RedisOm\Entity]
+#[RedisOm\Unique(properties: ['username', 'tenantId'])]
+#[RedisOm\Unique(properties: ['email',    'tenantId'])]
+class User
+{
+    #[RedisOm\Id]
+    #[RedisOm\Property]
+    public int $id;
+
+    #[RedisOm\Property]
+    public string $username;
+
+    #[RedisOm\Property]
+    public int $tenantId;
+
+    #[RedisOm\Property]
+    public string $email;
+}
+```
+
+The same `username` is allowed across different tenants; only the combination `(username, tenantId)` must be unique:
+
+```php
+// OK: same username, different tenants
+$u1 = new User(); $u1->id = 1; $u1->username = 'john'; $u1->tenantId = 1;
+$u2 = new User(); $u2->id = 2; $u2->username = 'john'; $u2->tenantId = 2;
+$objectManager->persist($u1);
+$objectManager->persist($u2);
+$objectManager->flush(); // succeeds
+
+// NOT OK: duplicate combination
+$u3 = new User(); $u3->id = 3; $u3->username = 'john'; $u3->tenantId = 1;
+$objectManager->persist($u3);
+$objectManager->flush(); // throws UniqueConstraintViolationException
+// Unique constraint violation on App\Entity\User: combination (tenantId="1", username="john") already exists.
+```
+
+### Behavior during merge and remove
+
+**merge():** when you load an object via `find()`, change a unique field, and call `merge()`, the library detects the change, deletes the old unique key and claims the new one — atomically. If the new value is already taken, `flush()` throws.
+
+```php
+$user = $objectManager->find(User::class, 1); // email = 'old@example.com'
+$user->email = 'new@example.com';
+
+$objectManager->merge($user);
+$objectManager->flush(); // old key released, new key claimed
+```
+
+**remove():** unique keys are deleted inside the same transaction as the object, so the value becomes immediately available for another object:
+
+```php
+$objectManager->remove($user);
+$objectManager->flush(); // unique key released
+
+$other->email = $user->email;
+$objectManager->persist($other);
+$objectManager->flush(); // succeeds
+```
+
+### Concurrency guarantee
+
+`flush()` uses Redis [WATCH][watch] + [MULTI][multi]/[EXEC][exec] to prevent race conditions: all relevant unique keys are watched before the transaction, checked for collisions, then written atomically. If a concurrent process claims the same key between `WATCH` and `EXEC`, the transaction is aborted and `UniqueConstraintViolationException::concurrentModification()` is thrown.
+
+### Limitations
+
+- Violations are detected only at `flush()` time, not at `persist()` or `merge()` time.
+- Unique fields must be scalar values (string, int, float). Arrays and nested objects are not supported.
+- `#[Unique]` does not imply `#[Property(index: true)]`. Add the index separately if you need to query by that field.
+- The library does not scan existing data when `#[Unique]` is added to an existing class. Run your own deduplication before deploying the constraint.
+
+[watch]: https://redis.io/docs/latest/commands/watch/
+[multi]: https://redis.io/docs/latest/commands/multi/
+[exec]:  https://redis.io/docs/latest/commands/exec/
+
 ## Update the schema
 After each modification of your classes, you have to update the schema in Redis. You can do it by running the following command:
 

--- a/src/Client/PredisClient.php
+++ b/src/Client/PredisClient.php
@@ -388,6 +388,38 @@ final class PredisClient implements RedisClientInterface
     /**
      * @inheritdoc
      */
+    public function get(string $key): ?string
+    {
+        return $this->redis->get(Converter::prefix($key));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function set(string $key, string $value): void
+    {
+        $this->redis->set(Converter::prefix($key), $value);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function watch(string ...$keys): void
+    {
+        $this->redis->watch(...array_map([Converter::class, 'prefix'], $keys));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function unwatch(): void
+    {
+        $this->redis->unwatch();
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function multi(): void
     {
         $this->redis->multi();
@@ -396,9 +428,9 @@ final class PredisClient implements RedisClientInterface
     /**
      * @inheritdoc
      */
-    public function exec(): void
+    public function exec(): bool
     {
-        $this->redis->exec();
+        return $this->redis->exec() !== null;
     }
 
     /**

--- a/src/Client/RedisClient.php
+++ b/src/Client/RedisClient.php
@@ -376,6 +376,39 @@ final class RedisClient implements RedisClientInterface
     /**
      * @inheritdoc
      */
+    public function get(string $key): ?string
+    {
+        $result = $this->redis->get(Converter::prefix($key));
+        return $result === false ? null : $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function set(string $key, string $value): void
+    {
+        $this->redis->set(Converter::prefix($key), $value);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function watch(string ...$keys): void
+    {
+        $this->redis->watch(array_map([Converter::class, 'prefix'], $keys));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function unwatch(): void
+    {
+        $this->redis->unwatch();
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function multi(): void
     {
         $this->redis->multi();
@@ -384,9 +417,9 @@ final class RedisClient implements RedisClientInterface
     /**
      * @inheritdoc
      */
-    public function exec(): void
+    public function exec(): bool
     {
-        $this->redis->exec();
+        return $this->redis->exec() !== false;
     }
 
     /**

--- a/src/Client/RedisClientInterface.php
+++ b/src/Client/RedisClientInterface.php
@@ -140,14 +140,35 @@ interface RedisClientInterface
     public function jsonGetMultiple(array $keys): array;
 
     /**
+     * Get a string value by key. Returns null when the key does not exist.
+     */
+    public function get(string $key): ?string;
+
+    /**
+     * Set a string value by key.
+     */
+    public function set(string $key, string $value): void;
+
+    /**
+     * Watch one or more keys for changes before a MULTI/EXEC transaction.
+     */
+    public function watch(string ...$keys): void;
+
+    /**
+     * Cancel all WATCHed keys without starting a transaction.
+     */
+    public function unwatch(): void;
+
+    /**
      * Begin a Redis transaction (MULTI).
      */
     public function multi(): void;
 
     /**
      * Execute a Redis transaction (EXEC).
+     * Returns false when a WATCHed key was modified and the transaction was aborted.
      */
-    public function exec(): void;
+    public function exec(): bool;
 
     /**
      * Discard a Redis transaction (DISCARD).

--- a/src/Exception/UniqueConstraintViolationException.php
+++ b/src/Exception/UniqueConstraintViolationException.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Exception;
+
+final class UniqueConstraintViolationException extends \RuntimeException
+{
+    public static function forField(string $class, string $field, mixed $value): self
+    {
+        return self::forFields($class, [$field], [(string) $value]);
+    }
+
+    /**
+     * @param string[] $fields
+     * @param string[] $values  Values in the same order as $fields.
+     */
+    public static function forFields(string $class, array $fields, array $values): self
+    {
+        if (count($fields) === 1) {
+            return new self(sprintf(
+                'Unique constraint violation on %s::%s, value "%s" already exists.',
+                $class,
+                $fields[0],
+                $values[0]
+            ));
+        }
+
+        $pairs = array_map(fn (string $f, string $v) => sprintf('%s="%s"', $f, $v), $fields, $values);
+
+        return new self(sprintf(
+            'Unique constraint violation on %s: combination (%s) already exists.',
+            $class,
+            implode(', ', $pairs)
+        ));
+    }
+
+    public static function concurrentModification(): self
+    {
+        return new self('Transaction aborted: a unique constraint key was modified concurrently. Retry the operation.');
+    }
+}

--- a/src/Om/Mapping/Property.php
+++ b/src/Om/Mapping/Property.php
@@ -10,7 +10,7 @@ use Attribute;
  * This attribute should be used to persist the properties of an entity in the Redis datastore.
  * You could leave the index true to benefits of automatic indexing,
  * #[Property(index: true)]  will enable an index for this property, by default it will be a text + tag index
- * Or you couldd specify the indexe(s) type(s) for each property you want to query :
+ * Or you could specify the indexe(s) type(s) for each property you want to query :
  * #[Property(type: ['title' => 'TEXT', 'title_tag' => 'TAG'])]
  * #[Property(type: ['price' => 'NUMERIC', 'price_tag' => 'TAG'])]
  */

--- a/src/Om/Mapping/Unique.php
+++ b/src/Om/Mapping/Unique.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Om\Mapping;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class Unique
+{
+    /**
+     * @param string[] $properties Field names for a composite unique constraint (class-level only).
+     *                             Leave empty when placed on a property.
+     */
+    public function __construct(
+        public readonly array $properties = [],
+    ) {
+    }
+}

--- a/src/Om/Persister/AbstractPersister.php
+++ b/src/Om/Persister/AbstractPersister.php
@@ -43,6 +43,7 @@ abstract class AbstractPersister implements PersisterInterface
             persisterClass: get_class($this),
             operation: PersisterOperations::OPERATION_DELETE->value,
             redisKey: $key,
+            value: $object,
         );
     }
 

--- a/src/Om/Persister/ObjectToPersist.php
+++ b/src/Om/Persister/ObjectToPersist.php
@@ -16,6 +16,7 @@ final class ObjectToPersist
         public object|array|null   $value = null,
         public ?int                $ttl = null,
         public ?array              $changedFields = null,
+        public ?array              $previousValues = null,
     ) {
     }
 }

--- a/src/Om/RedisObjectManager.php
+++ b/src/Om/RedisObjectManager.php
@@ -14,7 +14,9 @@ use Talleu\RedisOm\Event\LifecycleEventArgs;
 use Talleu\RedisOm\Om\Converters\HashModel\HashObjectConverter;
 use Talleu\RedisOm\Om\Converters\JsonModel\JsonObjectConverter;
 use Talleu\RedisOm\Om\Key\KeyGenerator;
+use Talleu\RedisOm\Exception\UniqueConstraintViolationException;
 use Talleu\RedisOm\Om\Mapping\Entity;
+use Talleu\RedisOm\Om\Mapping\Unique;
 use Talleu\RedisOm\Om\Metadata\ClassMetadata;
 use Talleu\RedisOm\Om\Metadata\MetadataFactory;
 use Talleu\RedisOm\Om\Persister\HashModel\HashPersister;
@@ -124,6 +126,7 @@ final class RedisObjectManager implements RedisObjectManagerInterface
             converter: $objectMapper->converter,
             value: $object,
             changedFields: $changedFields,
+            previousValues: $this->snapshots[$snapshotKey],
         );
 
         $this->objectsToFlush[$objectToMerge->persisterClass][$objectToMerge->operation][$objectToMerge->redisKey] = $objectToMerge;
@@ -169,25 +172,194 @@ final class RedisObjectManager implements RedisObjectManagerInterface
             return;
         }
 
+        $uniquePlan = $this->buildUniqueConstraintPlan();
+
+        if ($uniquePlan === null) {
+            $this->redisClient->multi();
+            try {
+                $this->doFlushOperations();
+                $this->redisClient->exec();
+            } catch (\Throwable $e) {
+                $this->redisClient->discard();
+                throw $e;
+            }
+            return;
+        }
+
+        $this->redisClient->watch(...array_keys($uniquePlan['watch']));
+
+        foreach ($uniquePlan['checks'] as $uniqueKey => $meta) {
+            $existingId = $this->redisClient->get($uniqueKey);
+            if ($existingId !== null && $existingId !== $meta['allowedId']) {
+                $this->redisClient->unwatch();
+                throw UniqueConstraintViolationException::forFields($meta['class'], $meta['fields'], $meta['values']);
+            }
+        }
+
         $this->redisClient->multi();
         try {
-            foreach ($this->objectsToFlush as $persisterClassName => $objectsByOperation) {
-                foreach ($objectsByOperation as $operation => $objectToPersists) {
-                    $this->persisters[$persisterClassName]->{$operation}($objectToPersists);
-                    foreach ($objectToPersists as $objectToPersist) {
-                        $this->eventManager->dispatchEvent(
-                            Events::POST_FLUSH,
-                            new LifecycleEventArgs($objectToPersist->value, $this)
-                        );
-                    }
-                    unset($this->objectsToFlush[$persisterClassName][$operation]);
-                }
+            $this->doFlushOperations();
+            foreach ($uniquePlan['sets'] as $uniqueKey => $id) {
+                $this->redisClient->set($uniqueKey, $id);
             }
-            $this->redisClient->exec();
+            foreach ($uniquePlan['dels'] as $uniqueKey) {
+                $this->redisClient->del($uniqueKey);
+            }
+            $committed = $this->redisClient->exec();
         } catch (\Throwable $e) {
             $this->redisClient->discard();
             throw $e;
         }
+
+        if (!$committed) {
+            throw UniqueConstraintViolationException::concurrentModification();
+        }
+    }
+
+    private function doFlushOperations(): void
+    {
+        foreach ($this->objectsToFlush as $persisterClassName => $objectsByOperation) {
+            foreach ($objectsByOperation as $operation => $objectToPersists) {
+                $this->persisters[$persisterClassName]->{$operation}($objectToPersists);
+                foreach ($objectToPersists as $objectToPersist) {
+                    $this->eventManager->dispatchEvent(
+                        Events::POST_FLUSH,
+                        new LifecycleEventArgs($objectToPersist->value, $this)
+                    );
+                }
+                unset($this->objectsToFlush[$persisterClassName][$operation]);
+            }
+        }
+    }
+
+    /**
+     * @return array{watch: array<string,true>, checks: array<string,array>, sets: array<string,string>, dels: list<string>}|null
+     */
+    private function buildUniqueConstraintPlan(): ?array
+    {
+        $watch = [];
+        $checks = [];
+        $sets = [];
+        $dels = [];
+
+        foreach ($this->objectsToFlush as $objectsByOperation) {
+            foreach ($objectsByOperation as $operation => $objectsToPersist) {
+                foreach ($objectsToPersist as $objectToPersist) {
+                    $object = $objectToPersist->value;
+                    $reflection = new \ReflectionClass($object);
+                    $idProperty = $this->keyGenerator->getIdentifier($reflection);
+                    $currentId = (string) $object->{$idProperty->getName()};
+                    $className = $reflection->getName();
+
+                    // Property-level #[Unique]
+                    foreach ($reflection->getProperties() as $property) {
+                        if ($property->getAttributes(Unique::class) === []) {
+                            continue;
+                        }
+
+                        $property->setAccessible(true);
+                        $fieldName = $property->getName();
+                        $currentValue = (string) $property->getValue($object);
+                        $uniqueKey = sprintf('unique:%s:%s:%s', $className, $fieldName, $currentValue);
+
+                        if ($operation === PersisterOperations::OPERATION_DELETE->value) {
+                            $watch[$uniqueKey] = true;
+                            $dels[] = $uniqueKey;
+                            continue;
+                        }
+
+                        if ($operation === PersisterOperations::OPERATION_MERGE->value) {
+                            $oldValue = isset($objectToPersist->previousValues[$fieldName])
+                                ? (string) $objectToPersist->previousValues[$fieldName]
+                                : null;
+
+                            if ($oldValue !== null && $oldValue !== $currentValue) {
+                                $oldUniqueKey = sprintf('unique:%s:%s:%s', $className, $fieldName, $oldValue);
+                                $watch[$oldUniqueKey] = true;
+                                $dels[] = $oldUniqueKey;
+                                $watch[$uniqueKey] = true;
+                                $checks[$uniqueKey] = ['allowedId' => $currentId, 'class' => $className, 'fields' => [$fieldName], 'values' => [$currentValue]];
+                                $sets[$uniqueKey] = $currentId;
+                            }
+                            continue;
+                        }
+
+                        if (isset($sets[$uniqueKey]) && $sets[$uniqueKey] !== $currentId) {
+                            throw UniqueConstraintViolationException::forFields($className, [$fieldName], [$currentValue]);
+                        }
+
+                        $watch[$uniqueKey] = true;
+                        $checks[$uniqueKey] = ['allowedId' => $currentId, 'class' => $className, 'fields' => [$fieldName], 'values' => [$currentValue]];
+                        $sets[$uniqueKey] = $currentId;
+                    }
+
+                    // Class-level #[Unique(properties: [...])]
+                    foreach ($reflection->getAttributes(Unique::class) as $attrRef) {
+                        $unique = $attrRef->newInstance();
+                        if ($unique->properties === []) {
+                            continue;
+                        }
+
+                        $fields = $unique->properties;
+                        sort($fields);
+
+                        $currentValues = [];
+                        foreach ($fields as $field) {
+                            $prop = $reflection->getProperty($field);
+                            $prop->setAccessible(true);
+                            $currentValues[$field] = (string) $prop->getValue($object);
+                        }
+
+                        $fieldKey = implode(',', $fields);
+                        $uniqueKey = sprintf('unique:%s:%s:%s', $className, $fieldKey, implode(':', array_values($currentValues)));
+
+                        if ($operation === PersisterOperations::OPERATION_DELETE->value) {
+                            $watch[$uniqueKey] = true;
+                            $dels[] = $uniqueKey;
+                            continue;
+                        }
+
+                        if ($operation === PersisterOperations::OPERATION_MERGE->value) {
+                            $oldValues = [];
+                            $anyChanged = false;
+                            foreach ($fields as $field) {
+                                $oldVal = isset($objectToPersist->previousValues[$field])
+                                    ? (string) $objectToPersist->previousValues[$field]
+                                    : null;
+                                $oldValues[$field] = $oldVal;
+                                if ($oldVal !== $currentValues[$field]) {
+                                    $anyChanged = true;
+                                }
+                            }
+
+                            if ($anyChanged && !in_array(null, $oldValues, true)) {
+                                $oldUniqueKey = sprintf('unique:%s:%s:%s', $className, $fieldKey, implode(':', array_values($oldValues)));
+                                $watch[$oldUniqueKey] = true;
+                                $dels[] = $oldUniqueKey;
+                                $watch[$uniqueKey] = true;
+                                $checks[$uniqueKey] = ['allowedId' => $currentId, 'class' => $className, 'fields' => $fields, 'values' => array_values($currentValues)];
+                                $sets[$uniqueKey] = $currentId;
+                            }
+                            continue;
+                        }
+
+                        if (isset($sets[$uniqueKey]) && $sets[$uniqueKey] !== $currentId) {
+                            throw UniqueConstraintViolationException::forFields($className, $fields, array_values($currentValues));
+                        }
+
+                        $watch[$uniqueKey] = true;
+                        $checks[$uniqueKey] = ['allowedId' => $currentId, 'class' => $className, 'fields' => $fields, 'values' => array_values($currentValues)];
+                        $sets[$uniqueKey] = $currentId;
+                    }
+                }
+            }
+        }
+
+        if ($watch === []) {
+            return null;
+        }
+
+        return ['watch' => $watch, 'checks' => $checks, 'sets' => $sets, 'dels' => $dels];
     }
 
     /**

--- a/tests/Fixtures/Hash/CompositeUniqueHash.php
+++ b/tests/Fixtures/Hash/CompositeUniqueHash.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Fixtures\Hash;
+
+use Talleu\RedisOm\Om\Mapping as RedisOm;
+
+#[RedisOm\Entity]
+#[RedisOm\Unique(properties: ['username', 'tenantId'])]
+class CompositeUniqueHash
+{
+    #[RedisOm\Id]
+    #[RedisOm\Property]
+    public ?int $id = null;
+
+    #[RedisOm\Property(index: true)]
+    public string $username = '';
+
+    #[RedisOm\Property(index: true)]
+    public int $tenantId = 0;
+
+    #[RedisOm\Property]
+    public string $email = '';
+}

--- a/tests/Fixtures/Hash/UniqueHash.php
+++ b/tests/Fixtures/Hash/UniqueHash.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Fixtures\Hash;
+
+use Talleu\RedisOm\Om\Mapping as RedisOm;
+
+#[RedisOm\Entity]
+class UniqueHash
+{
+    #[RedisOm\Id]
+    #[RedisOm\Property]
+    public ?int $id = null;
+
+    #[RedisOm\Property(index: true)]
+    #[RedisOm\Unique]
+    public string $email = '';
+
+    #[RedisOm\Property]
+    public string $name = '';
+}

--- a/tests/Fixtures/Json/CompositeUniqueJson.php
+++ b/tests/Fixtures/Json/CompositeUniqueJson.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Fixtures\Json;
+
+use Talleu\RedisOm\Om\Mapping as RedisOm;
+use Talleu\RedisOm\Om\RedisFormat;
+
+#[RedisOm\Entity(format: RedisFormat::JSON->value)]
+#[RedisOm\Unique(properties: ['username', 'tenantId'])]
+class CompositeUniqueJson
+{
+    #[RedisOm\Id]
+    #[RedisOm\Property]
+    public ?int $id = null;
+
+    #[RedisOm\Property(index: true)]
+    public string $username = '';
+
+    #[RedisOm\Property(index: true)]
+    public int $tenantId = 0;
+
+    #[RedisOm\Property]
+    public string $email = '';
+}

--- a/tests/Fixtures/Json/UniqueJson.php
+++ b/tests/Fixtures/Json/UniqueJson.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Fixtures\Json;
+
+use Talleu\RedisOm\Om\Mapping as RedisOm;
+use Talleu\RedisOm\Om\RedisFormat;
+
+#[RedisOm\Entity(format: RedisFormat::JSON->value)]
+class UniqueJson
+{
+    #[RedisOm\Id]
+    #[RedisOm\Property]
+    public ?int $id = null;
+
+    #[RedisOm\Property(index: true)]
+    #[RedisOm\Unique]
+    public string $email = '';
+
+    #[RedisOm\Property]
+    public string $name = '';
+}

--- a/tests/Functionnal/Om/Unique/UniqueConstraintTest.php
+++ b/tests/Functionnal/Om/Unique/UniqueConstraintTest.php
@@ -1,0 +1,354 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Functionnal\Om\Unique;
+
+use Talleu\RedisOm\Exception\UniqueConstraintViolationException;
+use Talleu\RedisOm\Om\RedisObjectManager;
+use Talleu\RedisOm\Tests\Fixtures\Hash\CompositeUniqueHash;
+use Talleu\RedisOm\Tests\Fixtures\Hash\UniqueHash;
+use Talleu\RedisOm\Tests\Fixtures\Json\CompositeUniqueJson;
+use Talleu\RedisOm\Tests\Fixtures\Json\UniqueJson;
+use Talleu\RedisOm\Tests\RedisAbstractTestCase;
+
+final class UniqueConstraintTest extends RedisAbstractTestCase
+{
+    private RedisObjectManager $om;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->om = new RedisObjectManager(self::createRedisClient());
+        static::emptyRedis();
+        static::generateIndex();
+    }
+
+    // -------------------------------------------------------------------------
+    // Property-level #[Unique] — Hash format
+    // -------------------------------------------------------------------------
+
+    public function testPersistDuplicateUniqueFieldHashThrows(): void
+    {
+        $user1 = $this->makeUniqueHash(1, 'john@example.com', 'John');
+        $this->om->persist($user1);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $user2 = $this->makeUniqueHash(2, 'john@example.com', 'Jane');
+        $om2->persist($user2);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+        $om2->flush();
+    }
+
+    public function testPersistSameFlushDuplicateUniqueFieldHashThrows(): void
+    {
+        $user1 = $this->makeUniqueHash(1, 'dup@example.com', 'Alice');
+        $user2 = $this->makeUniqueHash(2, 'dup@example.com', 'Bob');
+
+        $this->om->persist($user1);
+        $this->om->persist($user2);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+        $this->om->flush();
+    }
+
+    public function testPersistDistinctUniqueFieldsHashSucceeds(): void
+    {
+        $user1 = $this->makeUniqueHash(1, 'alice@example.com', 'Alice');
+        $user2 = $this->makeUniqueHash(2, 'bob@example.com', 'Bob');
+
+        $this->om->persist($user1);
+        $this->om->persist($user2);
+        $this->om->flush();
+
+        $this->assertNotNull($this->om->find(UniqueHash::class, 1));
+        $this->assertNotNull($this->om->find(UniqueHash::class, 2));
+    }
+
+    public function testRepersistSameObjectHashDoesNotThrow(): void
+    {
+        $user = $this->makeUniqueHash(1, 'same@example.com', 'John');
+        $this->om->persist($user);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $om2->persist($user);
+        $om2->flush();
+
+        $this->assertNotNull($om2->find(UniqueHash::class, 1));
+    }
+
+    public function testRemoveReleasesUniqueKeyHash(): void
+    {
+        $user = $this->makeUniqueHash(1, 'reclaim@example.com', 'John');
+        $this->om->persist($user);
+        $this->om->flush();
+
+        $this->om->remove($user);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $user2 = $this->makeUniqueHash(2, 'reclaim@example.com', 'Jane');
+        $om2->persist($user2);
+        $om2->flush();
+
+        $found = $om2->find(UniqueHash::class, 2);
+        $this->assertNotNull($found);
+        $this->assertSame('reclaim@example.com', $found->email);
+    }
+
+    public function testMergeChangingUniqueFieldHashSucceeds(): void
+    {
+        $user = $this->makeUniqueHash(1, 'old@example.com', 'John');
+        $this->om->persist($user);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $found = $om2->find(UniqueHash::class, 1);
+        $found->email = 'new@example.com';
+        $om2->merge($found);
+        $om2->flush();
+        $om2->clear();
+
+        $reloaded = $om2->find(UniqueHash::class, 1);
+        $this->assertSame('new@example.com', $reloaded->email);
+
+        // Old email must be released
+        $om3 = new RedisObjectManager(self::createRedisClient());
+        $other = $this->makeUniqueHash(2, 'old@example.com', 'Jane');
+        $om3->persist($other);
+        $om3->flush();
+        $this->assertNotNull($om3->find(UniqueHash::class, 2));
+    }
+
+    public function testMergeDuplicateUniqueFieldHashThrows(): void
+    {
+        $user1 = $this->makeUniqueHash(1, 'john@example.com', 'John');
+        $user2 = $this->makeUniqueHash(2, 'jane@example.com', 'Jane');
+        $this->om->persist($user1);
+        $this->om->persist($user2);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $found = $om2->find(UniqueHash::class, 2);
+        $found->email = 'john@example.com';
+        $om2->merge($found);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+        $om2->flush();
+    }
+
+    // -------------------------------------------------------------------------
+    // Property-level #[Unique] — Json format
+    // -------------------------------------------------------------------------
+
+    public function testPersistDuplicateUniqueFieldJsonThrows(): void
+    {
+        $user1 = $this->makeUniqueJson(1, 'john@example.com', 'John');
+        $this->om->persist($user1);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $user2 = $this->makeUniqueJson(2, 'john@example.com', 'Jane');
+        $om2->persist($user2);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+        $om2->flush();
+    }
+
+    public function testRemoveReleasesUniqueKeyJson(): void
+    {
+        $user = $this->makeUniqueJson(1, 'reclaim@example.com', 'John');
+        $this->om->persist($user);
+        $this->om->flush();
+
+        $this->om->remove($user);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $user2 = $this->makeUniqueJson(2, 'reclaim@example.com', 'Jane');
+        $om2->persist($user2);
+        $om2->flush();
+
+        $found = $om2->find(UniqueJson::class, 2);
+        $this->assertNotNull($found);
+        $this->assertSame('reclaim@example.com', $found->email);
+    }
+
+    // -------------------------------------------------------------------------
+    // Class-level #[Unique(properties: [...])] — Hash format
+    // -------------------------------------------------------------------------
+
+    public function testPersistDuplicateCompositeUniqueHashThrows(): void
+    {
+        $user1 = $this->makeCompositeHash(1, 'john', 1, 'john@example.com');
+        $this->om->persist($user1);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $user2 = $this->makeCompositeHash(2, 'john', 1, 'other@example.com');
+        $om2->persist($user2);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+        $om2->flush();
+    }
+
+    public function testPersistSameFlushDuplicateCompositeUniqueHashThrows(): void
+    {
+        $user1 = $this->makeCompositeHash(1, 'john', 1, 'a@example.com');
+        $user2 = $this->makeCompositeHash(2, 'john', 1, 'b@example.com');
+
+        $this->om->persist($user1);
+        $this->om->persist($user2);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+        $this->om->flush();
+    }
+
+    public function testPersistSameUsernamesDifferentTenantsHashSucceeds(): void
+    {
+        $user1 = $this->makeCompositeHash(1, 'john', 1, 'john@t1.com');
+        $user2 = $this->makeCompositeHash(2, 'john', 2, 'john@t2.com');
+
+        $this->om->persist($user1);
+        $this->om->persist($user2);
+        $this->om->flush();
+
+        $this->assertNotNull($this->om->find(CompositeUniqueHash::class, 1));
+        $this->assertNotNull($this->om->find(CompositeUniqueHash::class, 2));
+    }
+
+    public function testRemoveReleasesCompositeUniqueKeyHash(): void
+    {
+        $user = $this->makeCompositeHash(1, 'john', 1, 'john@example.com');
+        $this->om->persist($user);
+        $this->om->flush();
+
+        $this->om->remove($user);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $user2 = $this->makeCompositeHash(2, 'john', 1, 'john@example.com');
+        $om2->persist($user2);
+        $om2->flush();
+
+        $this->assertNotNull($om2->find(CompositeUniqueHash::class, 2));
+    }
+
+    // -------------------------------------------------------------------------
+    // Class-level #[Unique(properties: [...])] — Json format
+    // -------------------------------------------------------------------------
+
+    public function testPersistDuplicateCompositeUniqueJsonThrows(): void
+    {
+        $user1 = $this->makeCompositeJson(1, 'john', 1, 'john@example.com');
+        $this->om->persist($user1);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $user2 = $this->makeCompositeJson(2, 'john', 1, 'other@example.com');
+        $om2->persist($user2);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+        $om2->flush();
+    }
+
+    public function testPersistSameUsernamesDifferentTenantsJsonSucceeds(): void
+    {
+        $user1 = $this->makeCompositeJson(1, 'alice', 10, 'a@t10.com');
+        $user2 = $this->makeCompositeJson(2, 'alice', 20, 'a@t20.com');
+
+        $this->om->persist($user1);
+        $this->om->persist($user2);
+        $this->om->flush();
+
+        $this->assertNotNull($this->om->find(CompositeUniqueJson::class, 1));
+        $this->assertNotNull($this->om->find(CompositeUniqueJson::class, 2));
+    }
+
+    // -------------------------------------------------------------------------
+    // Exception message content
+    // -------------------------------------------------------------------------
+
+    public function testExceptionMessageContainsFieldAndValueForPropertyLevel(): void
+    {
+        $user1 = $this->makeUniqueHash(1, 'taken@example.com', 'John');
+        $this->om->persist($user1);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $user2 = $this->makeUniqueHash(2, 'taken@example.com', 'Jane');
+        $om2->persist($user2);
+
+        try {
+            $om2->flush();
+            $this->fail('Expected UniqueConstraintViolationException');
+        } catch (UniqueConstraintViolationException $e) {
+            $this->assertStringContainsString('email', $e->getMessage());
+            $this->assertStringContainsString('taken@example.com', $e->getMessage());
+        }
+    }
+
+    public function testExceptionMessageContainsBothFieldsForComposite(): void
+    {
+        $user1 = $this->makeCompositeHash(1, 'bob', 5, 'bob@example.com');
+        $this->om->persist($user1);
+        $this->om->flush();
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $user2 = $this->makeCompositeHash(2, 'bob', 5, 'other@example.com');
+        $om2->persist($user2);
+
+        try {
+            $om2->flush();
+            $this->fail('Expected UniqueConstraintViolationException');
+        } catch (UniqueConstraintViolationException $e) {
+            $this->assertStringContainsString('username', $e->getMessage());
+            $this->assertStringContainsString('tenantId', $e->getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makeUniqueHash(int $id, string $email, string $name): UniqueHash
+    {
+        $u = new UniqueHash();
+        $u->id = $id;
+        $u->email = $email;
+        $u->name = $name;
+        return $u;
+    }
+
+    private function makeUniqueJson(int $id, string $email, string $name): UniqueJson
+    {
+        $u = new UniqueJson();
+        $u->id = $id;
+        $u->email = $email;
+        $u->name = $name;
+        return $u;
+    }
+
+    private function makeCompositeHash(int $id, string $username, int $tenantId, string $email): CompositeUniqueHash
+    {
+        $u = new CompositeUniqueHash();
+        $u->id = $id;
+        $u->username = $username;
+        $u->tenantId = $tenantId;
+        $u->email = $email;
+        return $u;
+    }
+
+    private function makeCompositeJson(int $id, string $username, int $tenantId, string $email): CompositeUniqueJson
+    {
+        $u = new CompositeUniqueJson();
+        $u->id = $id;
+        $u->username = $username;
+        $u->tenantId = $tenantId;
+        $u->email = $email;
+        return $u;
+    }
+}

--- a/tests/Unit/Exception/UniqueConstraintViolationExceptionTest.php
+++ b/tests/Unit/Exception/UniqueConstraintViolationExceptionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Unit\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Talleu\RedisOm\Exception\UniqueConstraintViolationException;
+
+final class UniqueConstraintViolationExceptionTest extends TestCase
+{
+    public function testForFieldSingleFieldMessage(): void
+    {
+        $e = UniqueConstraintViolationException::forField('App\\Entity\\User', 'email', 'john@example.com');
+
+        $this->assertStringContainsString('App\\Entity\\User::email', $e->getMessage());
+        $this->assertStringContainsString('"john@example.com"', $e->getMessage());
+    }
+
+    public function testForFieldDelegatesToForFields(): void
+    {
+        $viaField  = UniqueConstraintViolationException::forField('Foo', 'bar', 'baz');
+        $viaFields = UniqueConstraintViolationException::forFields('Foo', ['bar'], ['baz']);
+
+        $this->assertSame($viaField->getMessage(), $viaFields->getMessage());
+    }
+
+    public function testForFieldsSingleElementUsesPropertyFormat(): void
+    {
+        $e = UniqueConstraintViolationException::forFields('My\\Entity', ['slug'], ['hello-world']);
+
+        $this->assertStringContainsString('My\\Entity::slug', $e->getMessage());
+        $this->assertStringContainsString('"hello-world"', $e->getMessage());
+    }
+
+    public function testForFieldsCompositeMessage(): void
+    {
+        $e = UniqueConstraintViolationException::forFields(
+            'App\\Entity\\User',
+            ['tenantId', 'username'],
+            ['42', 'john']
+        );
+
+        $this->assertStringContainsString('App\\Entity\\User', $e->getMessage());
+        $this->assertStringContainsString('tenantId="42"', $e->getMessage());
+        $this->assertStringContainsString('username="john"', $e->getMessage());
+        $this->assertStringNotContainsString('::', $e->getMessage());
+    }
+
+    public function testConcurrentModificationMessage(): void
+    {
+        $e = UniqueConstraintViolationException::concurrentModification();
+
+        $this->assertStringContainsString('concurrent', strtolower($e->getMessage()));
+    }
+
+    public function testAllFactoryMethodsReturnCorrectType(): void
+    {
+        $this->assertInstanceOf(UniqueConstraintViolationException::class, UniqueConstraintViolationException::forField('C', 'f', 'v'));
+        $this->assertInstanceOf(UniqueConstraintViolationException::class, UniqueConstraintViolationException::forFields('C', ['f'], ['v']));
+        $this->assertInstanceOf(UniqueConstraintViolationException::class, UniqueConstraintViolationException::concurrentModification());
+    }
+}


### PR DESCRIPTION
Ref: https://github.com/clementtalleu/php-redis-om/issues/142

Enforce uniqueness at flush() time using Redis WATCH + MULTI/EXEC, for both single-field (property-level) and composite (class-level, IS_REPEATABLE) constraints.

Implementation:
- New #[Unique] attribute (TARGET_PROPERTY | TARGET_CLASS | IS_REPEATABLE)
- New UniqueConstraintViolationException with forField(), forFields(), concurrentModification() factory methods
- RedisObjectManager.flush() split into a WATCH path (when unique constraints are present) and the original path (no constraints)
- buildUniqueConstraintPlan() collects unique keys to WATCH, GET-check, SET, and DEL across all pending operations (persist, merge, delete)
- Intra-flush collision detection: duplicate values in the same flush() call are caught before touching Redis
- ObjectToPersist.previousValues stores the pre-merge snapshot so flush() can resolve which unique key to delete when a unique field changes
- AbstractPersister.delete() now passes value: $object (was null, caused ReflectionClass crash when building the unique key on delete)
- RedisClientInterface extended with get(), set(), watch(), unwatch(); exec() return type changed from void to bool (false = WATCH triggered)
- Both RedisClient (ext-redis) and PredisClient implementations updated

Unique key format:
  unique:{className}:{field}:{value}           (single-field)
  unique:{className}:{f1,f2}:{v1}:{v2}        (composite, fields sorted)

Tests:
- 17 functional tests (UniqueConstraintTest): persist/same-flush/merge/remove scenarios for both Hash and Json formats, single-field and composite
- 6 unit tests (UniqueConstraintViolationExceptionTest)

Docs:
- docs/mapping.md: new "Unique constraints" section (single-field, composite, merge/remove behavior, concurrency guarantee, limitations)
- docs/advanced_usage.md: exception handling snippet with link to mapping.md