### PR TITLE
feat(repository): add stream() for memory-bounded iteration over large collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ with Redis.
 - PHP enum support (backed enums)
 - Identity map and dirty tracking with partial updates
 - Atomic transactions (MULTI/EXEC)
+- Unique constraints (single-field and composite)
 - Pagination with total count
+- Memory-efficient streaming of large collections
 - GEO queries (radius search)
 - Pipeline batch reads
 - API Platform support (beta)
@@ -284,6 +286,72 @@ Search objects within a geographic radius (requires a GEO-indexed property):
 public string $location; // Format: "longitude,latitude"
 
 $nearby = $repository->findByGeoRadius('location', 2.3522, 48.8566, 10, 'km');
+```
+
+## Unique Constraints 🔒
+
+Enforce uniqueness on one or more fields using `#[Unique]`.
+
+**Single field:**
+```php
+#[RedisOm\Entity]
+class User
+{
+    #[RedisOm\Id]
+    #[RedisOm\Property]
+    public int $id;
+
+    #[RedisOm\Property(index: true)]
+    #[RedisOm\Unique]
+    public string $email;
+}
+```
+
+**Composite (combination of fields must be unique):**
+```php
+#[RedisOm\Entity]
+#[RedisOm\Unique(properties: ['username', 'tenantId'])]
+class User
+{
+    #[RedisOm\Id]
+    #[RedisOm\Property]
+    public int $id;
+
+    #[RedisOm\Property]
+    public string $username;
+
+    #[RedisOm\Property]
+    public int $tenantId;
+}
+```
+
+`flush()` throws `UniqueConstraintViolationException` on conflict. Violations within the same `flush()` call are detected before hitting Redis. Concurrent writes are protected via Redis `WATCH`/`MULTI`/`EXEC`.
+
+```php
+use Talleu\RedisOm\Exception\UniqueConstraintViolationException;
+
+try {
+    $objectManager->persist($user);
+    $objectManager->flush();
+} catch (UniqueConstraintViolationException $e) {
+    // $e->getMessage() describes the conflicting field(s) and value(s)
+}
+```
+
+## Streaming Large Collections 🌊
+
+`findAll()` loads everything into memory. `stream()` fetches objects in batches and yields them one by one, keeping memory bounded regardless of collection size.
+
+```php
+// Via repository — full control
+foreach ($repository->stream(['status' => 'active'], batchSize: 500) as $user) {
+    // process $user — break works normally
+}
+
+// Via object manager — identity map is cleared automatically between batches
+foreach ($objectManager->stream(User::class, ['status' => 'active']) as $user) {
+    // process $user
+}
 ```
 
 ## Advanced documentation 📚

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -137,6 +137,58 @@ $userRepository->findOneBy(['createdAt' => '2021-01-01 00:00:00']);
 $userRepository->findBy(['createdAt' => '2021-01-01 00:00:00']); 
 ```
 
+## Streaming large collections
+
+`findAll()` loads the full collection in memory. For large datasets, use `stream()` which fetches objects in batches and yields them one by one, keeping memory bounded.
+
+### Via the repository
+
+```php
+// All objects, default batch size of 100
+foreach ($repository->stream() as $user) {
+    // process $user
+}
+
+// With criteria and custom batch size
+foreach ($repository->stream(['active' => true], batchSize: 500) as $user) {
+    // process $user
+}
+
+// With ordering
+foreach ($repository->stream(orderBy: ['createdAt' => 'ASC']) as $user) {
+    // process $user
+}
+```
+
+`break` works normally — the remaining batches are never fetched.
+
+Memory management is manual. If you call `merge()` inside the loop, the identity map grows by one entry per object. For long-running jobs, call `$objectManager->clear()` periodically to release it:
+
+```php
+foreach ($repository->stream(batchSize: 500) as $i => $user) {
+    // process...
+    if ($i % 500 === 499) {
+        $objectManager->flush();
+        $objectManager->clear();
+    }
+}
+```
+
+### Via the object manager (auto-clear)
+
+`RedisObjectManager::stream()` clears the identity map automatically after each batch, keeping memory flat with no manual intervention:
+
+```php
+foreach ($objectManager->stream(User::class, ['active' => true]) as $user) {
+    // process $user
+}
+```
+
+Two constraints to keep in mind:
+
+- Do not call `merge()` on an object once the generator has advanced past its batch — the snapshot is gone and the merge will silently fall back to a full persist.
+- Any pending operations not yet flushed are discarded at each batch boundary. Call `flush()` before streaming if you have queued writes.
+
 ## Repository
 
 You can create your own repository to query your objects in Redis. Then inject it in the

--- a/src/Om/RedisObjectManager.php
+++ b/src/Om/RedisObjectManager.php
@@ -398,6 +398,22 @@ final class RedisObjectManager implements RedisObjectManagerInterface
     /**
      * @inheritdoc
      */
+    public function stream(string $className, array $criteria = [], int $batchSize = 100): \Generator
+    {
+        $offset = 0;
+        do {
+            $batch = $this->getRepository($className)->findBy($criteria, null, $batchSize, $offset);
+            foreach ($batch as $object) {
+                yield $object;
+            }
+            $this->clear();
+            $offset += $batchSize;
+        } while (count($batch) === $batchSize);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function detach(object $object): void
     {
         $identifier = $this->keyGenerator->getIdentifier(new \ReflectionClass($object));

--- a/src/Om/RedisObjectManagerInterface.php
+++ b/src/Om/RedisObjectManagerInterface.php
@@ -38,6 +38,19 @@ interface RedisObjectManagerInterface
     public function clear(): void;
 
     /**
+     * Iterate over objects of a class, clearing the identity map after each batch.
+     * Keeps memory bounded for long-running jobs. Pending unflushed operations are discarded
+     * at each batch boundary — call flush() before streaming if you have queued writes.
+     * Objects from a previous batch are detached once the next batch starts; merge() on them
+     * falls back to a full persist.
+     * @template T of object
+     * @param class-string<T> $className
+     * @param array<string, mixed> $criteria
+     * @return \Generator<int, T>
+     */
+    public function stream(string $className, array $criteria = [], int $batchSize = 100): \Generator;
+
+    /**
      * Detach an object from the current unit of work, it will not be persisted nor deleted on flush.
      */
     public function detach(object $object): void;

--- a/src/Om/Repository/AbstractObjectRepository.php
+++ b/src/Om/Repository/AbstractObjectRepository.php
@@ -204,23 +204,25 @@ abstract class AbstractObjectRepository implements RepositoryInterface
      */
     public function findAll(): iterable
     {
-        $limit = self::DEFAULT_SEARCH_LIMIT;
+        return $this->stream(batchSize: self::DEFAULT_SEARCH_LIMIT);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function stream(
+        array $criteria = [],
+        ?array $orderBy = null,
+        int $batchSize = 100,
+    ): \Generator {
         $offset = 0;
-
         do {
-            $results = $this->findBy([], offset: $offset, limit: $limit);
-
-            if (empty($results)) {
-                break;
+            $batch = $this->findBy($criteria, $orderBy, $batchSize, $offset);
+            foreach ($batch as $object) {
+                yield $object;
             }
-
-            foreach ($results as $result) {
-                yield $result;
-            }
-
-            $offset += $limit;
-
-        } while (true);
+            $offset += $batchSize;
+        } while (count($batch) === $batchSize);
     }
 
     /**

--- a/src/Om/Repository/RepositoryInterface.php
+++ b/src/Om/Repository/RepositoryInterface.php
@@ -78,6 +78,19 @@ interface RepositoryInterface
     public function findAll(): iterable;
 
     /**
+     * Iterate over objects without loading the full collection in memory.
+     * Fetches $batchSize objects at a time and yields them one by one.
+     * @param array<string, mixed> $criteria
+     * @param array<string, string>|null $orderBy
+     * @return \Generator<int, T>
+     */
+    public function stream(
+        array $criteria = [],
+        ?array $orderBy = null,
+        int $batchSize = 100,
+    ): \Generator;
+
+    /**
      * Find one object by a set of criteria.
      * @param array<string, mixed> $criteria
      * @param array<string, string>|null $orderBy

--- a/tests/Fixtures/Hash/UuidStringDummyHash.php
+++ b/tests/Fixtures/Hash/UuidStringDummyHash.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Talleu\RedisOm\Tests\Fixtures\Hash;
 

--- a/tests/Fixtures/Json/UuidStringDummyJson.php
+++ b/tests/Fixtures/Json/UuidStringDummyJson.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Talleu\RedisOm\Tests\Fixtures\Json;
 

--- a/tests/Functionnal/Event/EventManagerTest.php
+++ b/tests/Functionnal/Event/EventManagerTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Talleu\RedisOm\Tests\Functionnal\Event;
 
@@ -19,7 +21,7 @@ final class EventManagerTest extends TestCase
 
     public function testAddEventListener(): void
     {
-        $listener = new class {
+        $listener = new class () {
             public bool $called = false;
 
             public function prePersist(EventArgs $args): void
@@ -35,7 +37,7 @@ final class EventManagerTest extends TestCase
 
     public function testAddEventListenerWithMultipleEvents(): void
     {
-        $listener = new class {
+        $listener = new class () {
             public int $callCount = 0;
 
             public function prePersist(EventArgs $args): void
@@ -58,7 +60,7 @@ final class EventManagerTest extends TestCase
 
     public function testRemoveEventListener(): void
     {
-        $listener = new class {
+        $listener = new class () {
             public bool $called = false;
 
             public function prePersist(EventArgs $args): void
@@ -76,7 +78,7 @@ final class EventManagerTest extends TestCase
 
     public function testAddEventSubscriber(): void
     {
-        $subscriber = new class implements EventSubscriberInterface {
+        $subscriber = new class () implements EventSubscriberInterface {
             public bool $called = false;
 
             public function getSubscribedEvents(): array
@@ -100,7 +102,7 @@ final class EventManagerTest extends TestCase
 
     public function testRemoveEventSubscriber(): void
     {
-        $subscriber = new class implements EventSubscriberInterface {
+        $subscriber = new class () implements EventSubscriberInterface {
             public bool $called = false;
 
             public function getSubscribedEvents(): array
@@ -128,7 +130,7 @@ final class EventManagerTest extends TestCase
         $object = new \stdClass();
         $object->name = 'test';
 
-        $listener = new class {
+        $listener = new class () {
             public ?object $receivedObject = null;
 
             public function prePersist(EventArgs $args): void
@@ -148,8 +150,10 @@ final class EventManagerTest extends TestCase
     {
         $this->assertFalse($this->eventManager->hasListeners(Events::PRE_PERSIST));
 
-        $listener = new class {
-            public function prePersist(EventArgs $args): void {}
+        $listener = new class () {
+            public function prePersist(EventArgs $args): void
+            {
+            }
         };
 
         $this->eventManager->addEventListener(Events::PRE_PERSIST, $listener);
@@ -158,11 +162,15 @@ final class EventManagerTest extends TestCase
 
     public function testGetListeners(): void
     {
-        $listener1 = new class {
-            public function prePersist(EventArgs $args): void {}
+        $listener1 = new class () {
+            public function prePersist(EventArgs $args): void
+            {
+            }
         };
-        $listener2 = new class {
-            public function prePersist(EventArgs $args): void {}
+        $listener2 = new class () {
+            public function prePersist(EventArgs $args): void
+            {
+            }
         };
 
         $this->eventManager->addEventListener(Events::PRE_PERSIST, $listener1);
@@ -198,8 +206,10 @@ final class EventManagerTest extends TestCase
     {
         $order = [];
 
-        $listener1 = new class($order) {
-            public function __construct(private array &$order) {}
+        $listener1 = new class ($order) {
+            public function __construct(private array &$order)
+            {
+            }
 
             public function prePersist(EventArgs $args): void
             {
@@ -207,8 +217,10 @@ final class EventManagerTest extends TestCase
             }
         };
 
-        $listener2 = new class($order) {
-            public function __construct(private array &$order) {}
+        $listener2 = new class ($order) {
+            public function __construct(private array &$order)
+            {
+            }
 
             public function prePersist(EventArgs $args): void
             {

--- a/tests/Functionnal/Event/LifecycleEventArgsTest.php
+++ b/tests/Functionnal/Event/LifecycleEventArgsTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Talleu\RedisOm\Tests\Functionnal\Event;
 

--- a/tests/Functionnal/Om/Mapping/PropertyIndexTest.php
+++ b/tests/Functionnal/Om/Mapping/PropertyIndexTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Talleu\RedisOm\Tests\Functionnal\Om\Mapping;
 

--- a/tests/Functionnal/Om/Repository/HashModel/StreamTest.php
+++ b/tests/Functionnal/Om/Repository/HashModel/StreamTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Functionnal\Om\Repository\HashModel;
+
+use Talleu\RedisOm\Om\RedisObjectManager;
+use Talleu\RedisOm\Tests\Fixtures\Hash\DummyHash;
+use Talleu\RedisOm\Tests\RedisAbstractTestCase;
+
+final class StreamTest extends RedisAbstractTestCase
+{
+    private RedisObjectManager $objectManager;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = new RedisObjectManager(RedisAbstractTestCase::createRedisClient());
+        parent::setUp();
+    }
+
+    public function testStreamYieldsAllObjects(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures();
+
+        $repository = $this->objectManager->getRepository(DummyHash::class);
+
+        $collected = [];
+        foreach ($repository->stream() as $dummy) {
+            $this->assertInstanceOf(DummyHash::class, $dummy);
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(3, $collected);
+    }
+
+    public function testStreamWithCriteria(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures();
+
+        $repository = $this->objectManager->getRepository(DummyHash::class);
+
+        $collected = [];
+        foreach ($repository->stream(['name' => 'Olivier']) as $dummy) {
+            $this->assertInstanceOf(DummyHash::class, $dummy);
+            $this->assertSame('Olivier', $dummy->name);
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(2, $collected);
+    }
+
+    public function testStreamWithOrderBy(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures();
+
+        $repository = $this->objectManager->getRepository(DummyHash::class);
+
+        $ages = [];
+        foreach ($repository->stream(orderBy: ['age' => 'ASC']) as $dummy) {
+            $ages[] = $dummy->age;
+        }
+
+        $sorted = $ages;
+        sort($sorted);
+        $this->assertSame($sorted, $ages);
+    }
+
+    public function testStreamEmptyCollection(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+
+        $repository = $this->objectManager->getRepository(DummyHash::class);
+
+        $collected = [];
+        foreach ($repository->stream() as $dummy) {
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(0, $collected);
+    }
+
+    public function testStreamWithSmallBatchSize(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures();
+
+        $repository = $this->objectManager->getRepository(DummyHash::class);
+
+        $collected = [];
+        foreach ($repository->stream(batchSize: 1) as $dummy) {
+            $this->assertInstanceOf(DummyHash::class, $dummy);
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(3, $collected);
+    }
+
+    public function testStreamBatchSizeExactMultipleOfTotal(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures();
+
+        $repository = $this->objectManager->getRepository(DummyHash::class);
+
+        $collected = [];
+        foreach ($repository->stream(batchSize: 3) as $dummy) {
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(3, $collected);
+    }
+
+    public function testManagerStreamYieldsAllObjects(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures();
+
+        $collected = [];
+        foreach ($this->objectManager->stream(DummyHash::class) as $dummy) {
+            $this->assertInstanceOf(DummyHash::class, $dummy);
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(3, $collected);
+    }
+
+    public function testManagerStreamWithCriteria(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures();
+
+        $collected = [];
+        foreach ($this->objectManager->stream(DummyHash::class, ['name' => 'Olivier']) as $dummy) {
+            $this->assertSame('Olivier', $dummy->name);
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(2, $collected);
+    }
+
+    public function testManagerStreamClearsIdentityMapAfterLastBatch(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        $fixtures = static::loadRedisFixtures();
+
+        $yielded = [];
+        foreach ($this->objectManager->stream(DummyHash::class, batchSize: 1) as $dummy) {
+            $yielded[] = $dummy;
+        }
+
+        $this->assertCount(3, $yielded);
+
+        // Identity map was cleared after the last batch: find() returns a fresh instance
+        $fresh = $this->objectManager->find(DummyHash::class, $fixtures[0]->id);
+        $this->assertNotSame($yielded[0], $fresh);
+    }
+}

--- a/tests/Functionnal/Om/Repository/JsonModel/StreamTest.php
+++ b/tests/Functionnal/Om/Repository/JsonModel/StreamTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Functionnal\Om\Repository\JsonModel;
+
+use Talleu\RedisOm\Om\RedisObjectManager;
+use Talleu\RedisOm\Tests\Fixtures\Json\DummyJson;
+use Talleu\RedisOm\Tests\RedisAbstractTestCase;
+
+final class StreamTest extends RedisAbstractTestCase
+{
+    private RedisObjectManager $objectManager;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = new RedisObjectManager(RedisAbstractTestCase::createRedisClient());
+        parent::setUp();
+    }
+
+    public function testStreamYieldsAllObjects(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures(DummyJson::class);
+
+        $repository = $this->objectManager->getRepository(DummyJson::class);
+
+        $collected = [];
+        foreach ($repository->stream() as $dummy) {
+            $this->assertInstanceOf(DummyJson::class, $dummy);
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(3, $collected);
+    }
+
+    public function testStreamWithCriteria(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures(DummyJson::class);
+
+        $repository = $this->objectManager->getRepository(DummyJson::class);
+
+        $collected = [];
+        foreach ($repository->stream(['name' => 'Olivier']) as $dummy) {
+            $this->assertInstanceOf(DummyJson::class, $dummy);
+            $this->assertSame('Olivier', $dummy->name);
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(2, $collected);
+    }
+
+    public function testStreamEmptyCollection(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+
+        $repository = $this->objectManager->getRepository(DummyJson::class);
+
+        $collected = [];
+        foreach ($repository->stream() as $dummy) {
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(0, $collected);
+    }
+
+    public function testStreamWithSmallBatchSize(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures(DummyJson::class);
+
+        $repository = $this->objectManager->getRepository(DummyJson::class);
+
+        $collected = [];
+        foreach ($repository->stream(batchSize: 1) as $dummy) {
+            $this->assertInstanceOf(DummyJson::class, $dummy);
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(3, $collected);
+    }
+
+    public function testManagerStreamYieldsAllObjects(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        static::loadRedisFixtures(DummyJson::class);
+
+        $collected = [];
+        foreach ($this->objectManager->stream(DummyJson::class) as $dummy) {
+            $this->assertInstanceOf(DummyJson::class, $dummy);
+            $collected[] = $dummy;
+        }
+
+        $this->assertCount(3, $collected);
+    }
+
+    public function testManagerStreamClearsIdentityMapAfterLastBatch(): void
+    {
+        static::emptyRedis();
+        static::generateIndex();
+        $fixtures = static::loadRedisFixtures(DummyJson::class);
+
+        $yielded = [];
+        foreach ($this->objectManager->stream(DummyJson::class, batchSize: 1) as $dummy) {
+            $yielded[] = $dummy;
+        }
+
+        $this->assertCount(3, $yielded);
+
+        $fresh = $this->objectManager->find(DummyJson::class, $fixtures[0]->id);
+        $this->assertNotSame($yielded[0], $fresh);
+    }
+}

--- a/tests/Unit/Event/EventManagerTest.php
+++ b/tests/Unit/Event/EventManagerTest.php
@@ -27,8 +27,10 @@ final class EventManagerTest extends TestCase
     public function testAddAndDispatchListener(): void
     {
         $called = false;
-        $listener = new class($called) {
-            public function __construct(private bool &$called) {}
+        $listener = new class ($called) {
+            public function __construct(private bool &$called)
+            {
+            }
             public function onTest(EventArgs $args): void
             {
                 $this->called = true;
@@ -44,8 +46,10 @@ final class EventManagerTest extends TestCase
 
     public function testRemoveEventListener(): void
     {
-        $listener = new class {
-            public function onTest(): void {}
+        $listener = new class () {
+            public function onTest(): void
+            {
+            }
         };
 
         $this->eventManager->addEventListener('onTest', $listener);
@@ -57,9 +61,13 @@ final class EventManagerTest extends TestCase
 
     public function testAddMultipleEvents(): void
     {
-        $listener = new class {
-            public function event1(): void {}
-            public function event2(): void {}
+        $listener = new class () {
+            public function event1(): void
+            {
+            }
+            public function event2(): void
+            {
+            }
         };
 
         $this->eventManager->addEventListener(['event1', 'event2'], $listener);
@@ -75,12 +83,14 @@ final class EventManagerTest extends TestCase
 
     public function testRemoveEventSubscriber(): void
     {
-        $subscriber = new class implements EventSubscriberInterface {
+        $subscriber = new class () implements EventSubscriberInterface {
             public function getSubscribedEvents(): array
             {
                 return ['event1' => 'onEvent1'];
             }
-            public function event1(): void {}
+            public function event1(): void
+            {
+            }
         };
 
         $this->eventManager->addEventSubscriber($subscriber);
@@ -93,8 +103,10 @@ final class EventManagerTest extends TestCase
     public function testDispatchWithCallableListener(): void
     {
         $called = false;
-        $listener = new class($called) {
-            public function __construct(private bool &$called) {}
+        $listener = new class ($called) {
+            public function __construct(private bool &$called)
+            {
+            }
             public function __invoke(EventArgs $args): void
             {
                 $this->called = true;
@@ -109,13 +121,23 @@ final class EventManagerTest extends TestCase
     public function testMultipleListenersOnSameEvent(): void
     {
         $count = 0;
-        $listener1 = new class($count) {
-            public function __construct(private int &$count) {}
-            public function onEvent(EventArgs $args): void { $this->count++; }
+        $listener1 = new class ($count) {
+            public function __construct(private int &$count)
+            {
+            }
+            public function onEvent(EventArgs $args): void
+            {
+                $this->count++;
+            }
         };
-        $listener2 = new class($count) {
-            public function __construct(private int &$count) {}
-            public function onEvent(EventArgs $args): void { $this->count++; }
+        $listener2 = new class ($count) {
+            public function __construct(private int &$count)
+            {
+            }
+            public function onEvent(EventArgs $args): void
+            {
+                $this->count++;
+            }
         };
 
         $this->eventManager->addEventListener('onEvent', $listener1);
@@ -127,7 +149,7 @@ final class EventManagerTest extends TestCase
 
     public function testRemoveListenerForNonExistentEvent(): void
     {
-        $listener = new class {};
+        $listener = new class () {};
 
         // Should not throw
         $this->eventManager->removeEventListener('nonExistent', $listener);

--- a/tests/Unit/Om/Converters/AbstractObjectConverterTest.php
+++ b/tests/Unit/Om/Converters/AbstractObjectConverterTest.php
@@ -131,8 +131,14 @@ class AOCTestPrivateWithGetter
     #[RedisOm\Property]
     private string $secret = '';
 
-    public function getSecret(): string { return $this->secret; }
-    public function setSecret(string $s): void { $this->secret = $s; }
+    public function getSecret(): string
+    {
+        return $this->secret;
+    }
+    public function setSecret(string $s): void
+    {
+        $this->secret = $s;
+    }
 }
 
 #[RedisOm\Entity]
@@ -145,8 +151,14 @@ class AOCTestPrivateWithCustomGetter
     #[RedisOm\Property(getter: 'fetchValue')]
     private string $value = '';
 
-    public function fetchValue(): string { return $this->value; }
-    public function setMyValue(string $v): void { $this->value = $v; }
+    public function fetchValue(): string
+    {
+        return $this->value;
+    }
+    public function setMyValue(string $v): void
+    {
+        $this->value = $v;
+    }
 }
 
 #[RedisOm\Entity]
@@ -181,8 +193,14 @@ class AOCTestPrivateWithCustomSetter
     #[RedisOm\Property(setter: 'writeValue')]
     private string $value = '';
 
-    public function writeValue(string $v): void { $this->value = $v; }
-    public function readValue(): string { return $this->value; }
+    public function writeValue(string $v): void
+    {
+        $this->value = $v;
+    }
+    public function readValue(): string
+    {
+        return $this->value;
+    }
 }
 
 #[RedisOm\Entity]
@@ -206,5 +224,8 @@ class AOCTestPrivateInvalidSetter
     #[RedisOm\Property(setter: 'nonExistentSetter')]
     private string $value = '';
 
-    public function getValue(): string { return $this->value; }
+    public function getValue(): string
+    {
+        return $this->value;
+    }
 }


### PR DESCRIPTION
Ref: https://github.com/clementtalleu/php-redis-om/issues/144

Introduces stream() on AbstractObjectRepository and RedisObjectManager, yielding objects in configurable batches without loading the full collection into memory.

- RepositoryInterface: add stream(criteria, orderBy, batchSize) signature
- AbstractObjectRepository: implement stream(); findAll() delegates to it
- RedisObjectManagerInterface/RedisObjectManager: add stream() with automatic identity map clearing between batches
- Tests: functional coverage for Hash and Json formats (criteria, orderBy, empty collection, small batchSize, exact batch multiple, manager variant with identity map verification)
- docs/advanced_usage.md: document both forms and their constraints
- README.md: add Unique Constraints and Streaming sections, update feature list
- style: apply php-cs-fixer to pre-existing violations in tests/