### PR TITLE
feat(repository): add bulkDelete() and bulkUpdate() for mass operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ with Redis.
 - Unique constraints (single-field and composite)
 - Pagination with total count
 - Memory-efficient streaming of large collections
+- Bulk delete and update without loading objects into memory
 - GEO queries (radius search)
 - Pipeline batch reads
 - API Platform support (beta)
@@ -337,6 +338,22 @@ try {
     // $e->getMessage() describes the conflicting field(s) and value(s)
 }
 ```
+
+## Bulk Operations ⚡
+
+Delete or update large numbers of objects without loading them into PHP memory.
+
+```php
+$repository = $objectManager->getRepository(User::class);
+
+// Delete all inactive users — unique-constraint keys are cleaned up automatically
+$deleted = $repository->bulkDelete(['status' => 'inactive']);
+
+// Update a scalar field on many objects at once
+$updated = $repository->bulkUpdate(['country' => 'FR'], ['currency' => 'EUR']);
+```
+
+`bulkUpdate()` throws `BulkOperationException` when `$changes` targets a `#[Unique]` field. Use `stream()` + `merge()` + `flush()` instead for those cases.
 
 ## Streaming Large Collections 🌊
 

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -189,6 +189,61 @@ Two constraints to keep in mind:
 - Do not call `merge()` on an object once the generator has advanced past its batch — the snapshot is gone and the merge will silently fall back to a full persist.
 - Any pending operations not yet flushed are discarded at each batch boundary. Call `flush()` before streaming if you have queued writes.
 
+## Bulk operations
+
+`bulkDelete()` and `bulkUpdate()` act directly on Redis keys without loading objects into PHP. They are designed for mass operations on large collections where per-object instantiation would be too costly.
+
+### `bulkDelete(array $criteria = []): int`
+
+Deletes all objects matching `$criteria` without loading them. Returns the number of deleted objects.
+
+Unique-constraint keys (`unique:*`) are cleaned up automatically so the deleted values become reusable immediately.
+
+```php
+$repository = $objectManager->getRepository(User::class);
+
+// Delete all inactive users
+$count = $repository->bulkDelete(['status' => 'inactive']);
+
+// Delete everything
+$count = $repository->bulkDelete();
+```
+
+### `bulkUpdate(array $criteria, array $changes): int`
+
+Updates specific fields on all objects matching `$criteria` without loading them. Returns the number of updated objects.
+
+Supports scalar types: `string`, `int`, `float`, `bool`, `null`. For complex types (dates, nested objects, enums), use `stream()` + `merge()` + `flush()`.
+
+```php
+// Set all trial users to active
+$count = $repository->bulkUpdate(['status' => 'trial'], ['status' => 'active']);
+
+// Reset a numeric field
+$count = $repository->bulkUpdate(['country' => 'FR'], ['score' => 0]);
+```
+
+Throws `BulkOperationException` if `$changes` targets a field covered by a `#[Unique]` constraint — updating a unique field in bulk would require complex collision handling that cannot be done safely without loading the objects:
+
+```php
+use Talleu\RedisOm\Exception\BulkOperationException;
+
+try {
+    $repository->bulkUpdate(['name' => 'John'], ['email' => 'new@example.com']);
+} catch (BulkOperationException $e) {
+    // Use stream() + merge() + flush() instead for unique fields
+}
+```
+
+### When to use bulk vs stream
+
+| Scenario | Recommended approach |
+|----------|----------------------|
+| Delete by criteria, no business logic | `bulkDelete()` |
+| Update scalar non-unique fields on many objects | `bulkUpdate()` |
+| Update unique fields | `stream()` + `merge()` + `flush()` |
+| Apply complex transformations or trigger events | `stream()` + `merge()` + `flush()` |
+
 ## Repository
 
 You can create your own repository to query your objects in Redis. Then inject it in the

--- a/src/Client/PredisClient.php
+++ b/src/Client/PredisClient.php
@@ -596,6 +596,96 @@ final class PredisClient implements RedisClientInterface
         return $this->extractRedisData($result, $format, $numberOfResults);
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function searchKeys(string $prefixKey, array $criteria, int $limit, int $offset): array
+    {
+        $arguments = [RedisCommands::SEARCH->value, Converter::prefix($prefixKey)];
+        $arguments[] = $criteria === [] ? '*' : $this->buildSearchCriteria($criteria);
+        $arguments[] = 'NOCONTENT';
+        $arguments[] = 'LIMIT';
+        $arguments[] = $offset;
+        $arguments[] = $limit;
+
+        try {
+            $result = call_user_func_array([$this->redis, 'executeRaw'], [$arguments]);
+        } catch (\RedisException $e) {
+            $this->handleError(RedisCommands::SEARCH->value, $e->getMessage(), $e);
+        }
+
+        if ($result === false || $result[0] === 0) {
+            return [];
+        }
+
+        return array_slice((array) $result, 1);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function searchKeysWithFields(string $prefixKey, array $criteria, array $fields, int $limit, int $offset): array
+    {
+        $arguments = [RedisCommands::SEARCH->value, Converter::prefix($prefixKey)];
+        $arguments[] = $criteria === [] ? '*' : $this->buildSearchCriteria($criteria);
+        $arguments[] = 'RETURN';
+        $arguments[] = (string) count($fields);
+        foreach ($fields as $field) {
+            $arguments[] = $field;
+        }
+        $arguments[] = 'LIMIT';
+        $arguments[] = $offset;
+        $arguments[] = $limit;
+
+        try {
+            $result = call_user_func_array([$this->redis, 'executeRaw'], [$arguments]);
+        } catch (\RedisException $e) {
+            $this->handleError(RedisCommands::SEARCH->value, $e->getMessage(), $e);
+        }
+
+        if ($result === false || $result[0] === 0) {
+            return [];
+        }
+
+        $entries = [];
+        $result = (array) $result;
+        for ($i = 1, $max = count($result); $i < $max; $i += 2) {
+            $rawFields = (array) ($result[$i + 1] ?? []);
+            $parsed = [];
+            for ($j = 0, $jMax = count($rawFields); $j < $jMax; $j += 2) {
+                $parsed[$rawFields[$j]] = $rawFields[$j + 1] ?? null;
+            }
+            $entries[] = ['key' => $result[$i], 'fields' => $parsed];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function delMultiple(array $keys): void
+    {
+        if ($keys === []) {
+            return;
+        }
+
+        $this->redis->del(array_map([Converter::class, 'prefix'], $keys));
+    }
+
+    private function buildSearchCriteria(array $criteria): string
+    {
+        $query = '';
+        foreach ($criteria as $property => $value) {
+            if (is_string($value) && str_contains($value, '-')) {
+                $value = str_replace('-', '\-', $value);
+            }
+            $query .= sprintf('@%s:{%s}', $property, $value);
+        }
+
+        return $query;
+    }
+
     private function handleError(string $command, ?string $errorMessage = 'Unknown error', ?\Throwable $previous = null): never
     {
         throw new RedisClientResponseException(

--- a/src/Client/RedisClient.php
+++ b/src/Client/RedisClient.php
@@ -581,6 +581,95 @@ final class RedisClient implements RedisClientInterface
         return $this->extractRedisData($result, $format, $numberOfResults);
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function searchKeys(string $prefixKey, array $criteria, int $limit, int $offset): array
+    {
+        $arguments = [RedisCommands::SEARCH->value, Converter::prefix($prefixKey)];
+        $arguments[] = $criteria === [] ? '*' : $this->buildSearchCriteria($criteria);
+        $arguments[] = 'NOCONTENT';
+        $arguments[] = 'LIMIT';
+        $arguments[] = $offset;
+        $arguments[] = $limit;
+
+        try {
+            $result = call_user_func_array([$this->redis, 'rawCommand'], $arguments);
+        } catch (\RedisException $e) {
+            $this->handleError(RedisCommands::SEARCH->value, $e->getMessage(), $e);
+        }
+
+        if ($result === false || $result[0] === 0) {
+            return [];
+        }
+
+        return array_slice($result, 1);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function searchKeysWithFields(string $prefixKey, array $criteria, array $fields, int $limit, int $offset): array
+    {
+        $arguments = [RedisCommands::SEARCH->value, Converter::prefix($prefixKey)];
+        $arguments[] = $criteria === [] ? '*' : $this->buildSearchCriteria($criteria);
+        $arguments[] = 'RETURN';
+        $arguments[] = (string) count($fields);
+        foreach ($fields as $field) {
+            $arguments[] = $field;
+        }
+        $arguments[] = 'LIMIT';
+        $arguments[] = $offset;
+        $arguments[] = $limit;
+
+        try {
+            $result = call_user_func_array([$this->redis, 'rawCommand'], $arguments);
+        } catch (\RedisException $e) {
+            $this->handleError(RedisCommands::SEARCH->value, $e->getMessage(), $e);
+        }
+
+        if ($result === false || $result[0] === 0) {
+            return [];
+        }
+
+        $entries = [];
+        for ($i = 1, $max = count($result); $i < $max; $i += 2) {
+            $rawFields = (array) ($result[$i + 1] ?? []);
+            $parsed = [];
+            for ($j = 0, $jMax = count($rawFields); $j < $jMax; $j += 2) {
+                $parsed[$rawFields[$j]] = $rawFields[$j + 1] ?? null;
+            }
+            $entries[] = ['key' => $result[$i], 'fields' => $parsed];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function delMultiple(array $keys): void
+    {
+        if ($keys === []) {
+            return;
+        }
+
+        $this->redis->del(array_map([Converter::class, 'prefix'], $keys));
+    }
+
+    private function buildSearchCriteria(array $criteria): string
+    {
+        $query = '';
+        foreach ($criteria as $property => $value) {
+            if (is_string($value) && str_contains($value, '-')) {
+                $value = str_replace('-', '\-', $value);
+            }
+            $query .= sprintf('@%s:{%s}', $property, $value);
+        }
+
+        return $query;
+    }
+
     private function handleError(string $command, ?string $errorMessage = 'Unknown error', ?\Throwable $previous = null): never
     {
         throw new RedisClientResponseException(

--- a/src/Client/RedisClientInterface.php
+++ b/src/Client/RedisClientInterface.php
@@ -182,4 +182,22 @@ interface RedisClientInterface
      * @return array<int, array<string, string>>
      */
     public function getIndexInfo(string $prefixKey): array;
+
+    /**
+     * Search and return only key names (NOCONTENT) — no document data deserialized.
+     * @return string[]
+     */
+    public function searchKeys(string $prefixKey, array $criteria, int $limit, int $offset): array;
+
+    /**
+     * Search and return key names with selected field values.
+     * Each entry: ['key' => string, 'fields' => ['field' => value]].
+     */
+    public function searchKeysWithFields(string $prefixKey, array $criteria, array $fields, int $limit, int $offset): array;
+
+    /**
+     * Delete multiple keys in a single DEL command.
+     * @param string[] $keys Raw Redis keys (already normalized, e.g. from searchKeys/searchKeysWithFields).
+     */
+    public function delMultiple(array $keys): void;
 }

--- a/src/Exception/BulkOperationException.php
+++ b/src/Exception/BulkOperationException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Exception;
+
+final class BulkOperationException extends \RuntimeException
+{
+    /**
+     * @param string[] $fields
+     */
+    public static function uniqueFieldsCannotBeBulkUpdated(string $className, array $fields): self
+    {
+        return new self(sprintf(
+            'Cannot bulk-update unique fields [%s] on %s. Use stream() + merge() + flush() instead.',
+            implode(', ', $fields),
+            $className,
+        ));
+    }
+}

--- a/src/Om/Metadata/ClassMetadata.php
+++ b/src/Om/Metadata/ClassMetadata.php
@@ -12,6 +12,8 @@ class ClassMetadata implements MetadataInterface
         public ?array $fieldsMapping = [],
         public ?array $associations = [],
         public ?array $typesFields = [],
+        /** @var string[][] Each entry is a group of field names forming a unique constraint */
+        public array $uniqueConstraints = [],
     ) {
     }
 
@@ -133,5 +135,21 @@ class ClassMetadata implements MetadataInterface
     public function setTypesFields(array $fields)
     {
         $this->typesFields = $fields;
+    }
+
+    public function setUniqueConstraints(array $constraints): void
+    {
+        $this->uniqueConstraints = $constraints;
+    }
+
+    public function hasUniqueConstraints(): bool
+    {
+        return $this->uniqueConstraints !== [];
+    }
+
+    /** @return string[] All field names involved in any unique constraint */
+    public function getUniqueFields(): array
+    {
+        return array_unique(array_merge(...$this->uniqueConstraints));
     }
 }

--- a/src/Om/Metadata/MetadataFactory.php
+++ b/src/Om/Metadata/MetadataFactory.php
@@ -7,6 +7,7 @@ namespace Talleu\RedisOm\Om\Metadata;
 use Talleu\RedisOm\Om\Mapping\Entity;
 use Talleu\RedisOm\Om\Mapping\Id;
 use Talleu\RedisOm\Om\Mapping\Property;
+use Talleu\RedisOm\Om\Mapping\Unique;
 
 class MetadataFactory
 {
@@ -19,6 +20,7 @@ class MetadataFactory
         $classMetadata->setFieldsMapping($this->buildFieldsMapping());
         $classMetadata->setAssociations($this->buildAssociations());
         $classMetadata->setTypesFields($this->buildTypesFields());
+        $classMetadata->setUniqueConstraints($this->buildUniqueConstraints());
 
         return $classMetadata;
     }
@@ -94,5 +96,25 @@ class MetadataFactory
         }
 
         return $fields;
+    }
+
+    private function buildUniqueConstraints(): array
+    {
+        $constraints = [];
+
+        foreach ($this->reflectionClass->getProperties() as $property) {
+            if ($property->getAttributes(Unique::class) !== []) {
+                $constraints[] = [$property->getName()];
+            }
+        }
+
+        foreach ($this->reflectionClass->getAttributes(Unique::class) as $attr) {
+            $unique = $attr->newInstance();
+            if ($unique->properties !== []) {
+                $constraints[] = $unique->properties;
+            }
+        }
+
+        return $constraints;
     }
 }

--- a/src/Om/RedisObjectManager.php
+++ b/src/Om/RedisObjectManager.php
@@ -16,7 +16,6 @@ use Talleu\RedisOm\Om\Converters\JsonModel\JsonObjectConverter;
 use Talleu\RedisOm\Om\Key\KeyGenerator;
 use Talleu\RedisOm\Exception\UniqueConstraintViolationException;
 use Talleu\RedisOm\Om\Mapping\Entity;
-use Talleu\RedisOm\Om\Mapping\Unique;
 use Talleu\RedisOm\Om\Metadata\ClassMetadata;
 use Talleu\RedisOm\Om\Metadata\MetadataFactory;
 use Talleu\RedisOm\Om\Persister\HashModel\HashPersister;
@@ -36,6 +35,9 @@ final class RedisObjectManager implements RedisObjectManagerInterface
 
     /** @var array<string, Entity> */
     private array $entityMapperCache = [];
+
+    /** @var array<string, ClassMetadata> */
+    private array $classMetadataCache = [];
 
     /** @var array<string, array<string|int, object>> Identity map: className -> id -> object */
     private array $identityMap = [];
@@ -246,68 +248,22 @@ final class RedisObjectManager implements RedisObjectManagerInterface
             foreach ($objectsByOperation as $operation => $objectsToPersist) {
                 foreach ($objectsToPersist as $objectToPersist) {
                     $object = $objectToPersist->value;
-                    $reflection = new \ReflectionClass($object);
-                    $idProperty = $this->keyGenerator->getIdentifier($reflection);
-                    $currentId = (string) $object->{$idProperty->getName()};
-                    $className = $reflection->getName();
+                    $className = get_class($object);
+                    $metadata = $this->getCachedClassMetadata($className);
 
-                    // Property-level #[Unique]
-                    foreach ($reflection->getProperties() as $property) {
-                        if ($property->getAttributes(Unique::class) === []) {
-                            continue;
-                        }
-
-                        $property->setAccessible(true);
-                        $fieldName = $property->getName();
-                        $currentValue = (string) $property->getValue($object);
-                        $uniqueKey = sprintf('unique:%s:%s:%s', $className, $fieldName, $currentValue);
-
-                        if ($operation === PersisterOperations::OPERATION_DELETE->value) {
-                            $watch[$uniqueKey] = true;
-                            $dels[] = $uniqueKey;
-                            continue;
-                        }
-
-                        if ($operation === PersisterOperations::OPERATION_MERGE->value) {
-                            $oldValue = isset($objectToPersist->previousValues[$fieldName])
-                                ? (string) $objectToPersist->previousValues[$fieldName]
-                                : null;
-
-                            if ($oldValue !== null && $oldValue !== $currentValue) {
-                                $oldUniqueKey = sprintf('unique:%s:%s:%s', $className, $fieldName, $oldValue);
-                                $watch[$oldUniqueKey] = true;
-                                $dels[] = $oldUniqueKey;
-                                $watch[$uniqueKey] = true;
-                                $checks[$uniqueKey] = ['allowedId' => $currentId, 'class' => $className, 'fields' => [$fieldName], 'values' => [$currentValue]];
-                                $sets[$uniqueKey] = $currentId;
-                            }
-                            continue;
-                        }
-
-                        if (isset($sets[$uniqueKey]) && $sets[$uniqueKey] !== $currentId) {
-                            throw UniqueConstraintViolationException::forFields($className, [$fieldName], [$currentValue]);
-                        }
-
-                        $watch[$uniqueKey] = true;
-                        $checks[$uniqueKey] = ['allowedId' => $currentId, 'class' => $className, 'fields' => [$fieldName], 'values' => [$currentValue]];
-                        $sets[$uniqueKey] = $currentId;
+                    if (!$metadata->hasUniqueConstraints()) {
+                        continue;
                     }
 
-                    // Class-level #[Unique(properties: [...])]
-                    foreach ($reflection->getAttributes(Unique::class) as $attrRef) {
-                        $unique = $attrRef->newInstance();
-                        if ($unique->properties === []) {
-                            continue;
-                        }
+                    $idFieldName = $metadata->identifier[0];
+                    $currentId = (string) (new \ReflectionProperty($className, $idFieldName))->getValue($object);
 
-                        $fields = $unique->properties;
+                    foreach ($metadata->uniqueConstraints as $fields) {
                         sort($fields);
 
                         $currentValues = [];
                         foreach ($fields as $field) {
-                            $prop = $reflection->getProperty($field);
-                            $prop->setAccessible(true);
-                            $currentValues[$field] = (string) $prop->getValue($object);
+                            $currentValues[$field] = (string) (new \ReflectionProperty($className, $field))->getValue($object);
                         }
 
                         $fieldKey = implode(',', $fields);
@@ -360,6 +316,11 @@ final class RedisObjectManager implements RedisObjectManagerInterface
         }
 
         return ['watch' => $watch, 'checks' => $checks, 'sets' => $sets, 'dels' => $dels];
+    }
+
+    private function getCachedClassMetadata(string $className): ClassMetadata
+    {
+        return $this->classMetadataCache[$className] ??= (new MetadataFactory())->createClassMetadata($className);
     }
 
     /**

--- a/src/Om/Repository/AbstractObjectRepository.php
+++ b/src/Om/Repository/AbstractObjectRepository.php
@@ -7,10 +7,13 @@ namespace Talleu\RedisOm\Om\Repository;
 use Talleu\RedisOm\Client\Helper\Converter;
 use Talleu\RedisOm\Client\RedisClientInterface;
 use Talleu\RedisOm\Exception\BadIdentifierConfigurationException;
+use Talleu\RedisOm\Exception\BulkOperationException;
 use Talleu\RedisOm\Om\Converters\AbstractDateTimeConverter;
 use Talleu\RedisOm\Om\Converters\ConverterInterface;
 use Talleu\RedisOm\Om\Mapping\Id;
 use Talleu\RedisOm\Om\Mapping\Property;
+use Talleu\RedisOm\Om\Metadata\ClassMetadata;
+use Talleu\RedisOm\Om\Metadata\MetadataFactory;
 use Talleu\RedisOm\Om\Paginator;
 use Talleu\RedisOm\Om\QueryBuilder;
 use Talleu\RedisOm\Om\RedisFormat;
@@ -21,9 +24,16 @@ abstract class AbstractObjectRepository implements RepositoryInterface
     public ?string $className = null;
     protected ?RedisClientInterface $redisClient = null;
     protected ?ConverterInterface $converter = null;
+    private ?ClassMetadata $classMetadata = null;
     private const DEFAULT_SEARCH_LIMIT = 10000;
+
     public function __construct(public ?string $format = null)
     {
+    }
+
+    protected function getClassMetadata(): ClassMetadata
+    {
+        return $this->classMetadata ??= (new MetadataFactory())->createClassMetadata($this->className);
     }
 
     /**
@@ -292,6 +302,149 @@ abstract class AbstractObjectRepository implements RepositoryInterface
         }
 
         return $this->redisClient->count($this->prefix, $criteria, Property::INDEX_TEXT);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function bulkDelete(array $criteria = []): int
+    {
+        $metadata = $this->getClassMetadata();
+        $uniqueConstraints = $metadata->uniqueConstraints;
+        $batchSize = 100;
+        $deleted = 0;
+        $batchCount = 0;
+
+        $this->convertObjects($criteria);
+        $this->convertDates($criteria);
+        $this->convertSpecial($criteria);
+
+        do {
+            if ($uniqueConstraints === []) {
+                // No unique keys to clean up: fetch only key names
+                $keys = $this->redisClient->searchKeys($this->prefix, $criteria, $batchSize, 0);
+                $batchCount = count($keys);
+                if ($batchCount > 0) {
+                    $this->redisClient->delMultiple($keys);
+                    $deleted += $batchCount;
+                }
+            } else {
+                // Fetch key names + unique-field values to delete constraint keys
+                $uniqueFields = $metadata->getUniqueFields();
+                $searchFields = $this->format === RedisFormat::JSON->value
+                    ? array_map(fn ($f) => '$.' . $f, $uniqueFields)
+                    : $uniqueFields;
+
+                $entries = $this->redisClient->searchKeysWithFields($this->prefix, $criteria, $searchFields, $batchSize, 0);
+                $batchCount = count($entries);
+                if ($batchCount > 0) {
+                    $isJson = $this->format === RedisFormat::JSON->value;
+                    $keysToDelete = [];
+                    foreach ($entries as $entry) {
+                        $keysToDelete[] = $entry['key'];
+                        $fieldValues = $this->normalizeFieldNames($entry['fields']);
+                        foreach ($uniqueConstraints as $fields) {
+                            $sortedFields = $fields;
+                            sort($sortedFields);
+                            $values = array_map(function (string $f) use ($fieldValues, $isJson): string {
+                                $raw = (string) ($fieldValues[$f] ?? '');
+                                // FT.SEARCH RETURN wraps JSON path results in an array: ["actual_value"]
+                                if ($isJson && str_starts_with($raw, '[')) {
+                                    $decoded = json_decode($raw, true);
+                                    return (string) (is_array($decoded) ? ($decoded[0] ?? '') : $decoded);
+                                }
+                                return $raw;
+                            }, $sortedFields);
+                            $keysToDelete[] = sprintf(
+                                'unique:%s:%s:%s',
+                                $this->className,
+                                implode(',', $sortedFields),
+                                implode(':', $values),
+                            );
+                        }
+                    }
+                    $this->redisClient->delMultiple($keysToDelete);
+                    $deleted += $batchCount;
+                }
+            }
+        } while ($batchCount === $batchSize);
+
+        return $deleted;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function bulkUpdate(array $criteria, array $changes): int
+    {
+        $metadata = $this->getClassMetadata();
+        $conflictingFields = array_values(array_intersect(array_keys($changes), $metadata->getUniqueFields()));
+        if ($conflictingFields !== []) {
+            throw BulkOperationException::uniqueFieldsCannotBeBulkUpdated($this->className, $conflictingFields);
+        }
+
+        $this->convertObjects($criteria);
+        $this->convertDates($criteria);
+        $this->convertSpecial($criteria);
+
+        $isJson = $this->format === RedisFormat::JSON->value;
+        $batchSize = 100;
+        $offset = 0;
+        $updated = 0;
+
+        do {
+            $keys = $this->redisClient->searchKeys($this->prefix, $criteria, $batchSize, $offset);
+            $batchCount = count($keys);
+
+            if ($batchCount > 0) {
+                if ($isJson) {
+                    foreach ($keys as $key) {
+                        foreach ($changes as $field => $value) {
+                            $this->redisClient->jsonSetProperty($key, $field, (string) json_encode($value));
+                        }
+                    }
+                } else {
+                    $convertedChanges = $this->convertChangesForHash($changes);
+                    foreach ($keys as $key) {
+                        $this->redisClient->hMSet($key, $convertedChanges);
+                    }
+                }
+                $updated += $batchCount;
+            }
+
+            $offset += $batchSize;
+        } while ($batchCount === $batchSize);
+
+        return $updated;
+    }
+
+    /**
+     * Strips `$.` JSON path prefix from field names returned by FT.SEARCH RETURN.
+     * @param array<string, mixed> $fields
+     * @return array<string, mixed>
+     */
+    private function normalizeFieldNames(array $fields): array
+    {
+        $normalized = [];
+        foreach ($fields as $fieldName => $value) {
+            $normalized[str_starts_with($fieldName, '$.') ? substr($fieldName, 2) : $fieldName] = $value;
+        }
+
+        return $normalized;
+    }
+
+    private function convertChangesForHash(array $changes): array
+    {
+        $converted = [];
+        foreach ($changes as $field => $value) {
+            $converted[$field] = match (true) {
+                is_null($value) => 'null',
+                is_bool($value) => $value ? 'true' : 'false',
+                default => (string) $value,
+            };
+        }
+
+        return $converted;
     }
 
     /**

--- a/src/Om/Repository/RepositoryInterface.php
+++ b/src/Om/Repository/RepositoryInterface.php
@@ -155,4 +155,22 @@ interface RepositoryInterface
      * Create a new QueryBuilder instance.
      */
     public function createQueryBuilder(): QueryBuilder;
+
+    /**
+     * Delete all objects matching $criteria without loading them into memory.
+     * Unique-constraint keys are cleaned up automatically.
+     * Returns the number of deleted objects.
+     * @param array<string, mixed> $criteria
+     */
+    public function bulkDelete(array $criteria = []): int;
+
+    /**
+     * Update specific fields on all objects matching $criteria without loading them.
+     * Throws BulkOperationException if $changes targets a field covered by a unique constraint.
+     * Supports scalar types (string, int, float, bool, null). Use stream() + merge() + flush() for complex types.
+     * Returns the number of updated objects.
+     * @param array<string, mixed> $criteria
+     * @param array<string, mixed> $changes  field => new value
+     */
+    public function bulkUpdate(array $criteria, array $changes): int;
 }

--- a/tests/Functionnal/Om/Bulk/BulkHashTest.php
+++ b/tests/Functionnal/Om/Bulk/BulkHashTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Functionnal\Om\Bulk;
+
+use Talleu\RedisOm\Exception\BulkOperationException;
+use Talleu\RedisOm\Om\RedisObjectManager;
+use Talleu\RedisOm\Tests\Fixtures\Hash\CompositeUniqueHash;
+use Talleu\RedisOm\Tests\Fixtures\Hash\DummyHash;
+use Talleu\RedisOm\Tests\Fixtures\Hash\UniqueHash;
+use Talleu\RedisOm\Tests\RedisAbstractTestCase;
+
+final class BulkHashTest extends RedisAbstractTestCase
+{
+    private RedisObjectManager $om;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->om = new RedisObjectManager(self::createRedisClient());
+        static::emptyRedis();
+        static::generateIndex();
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkDelete — no unique constraints
+    // -------------------------------------------------------------------------
+
+    public function testBulkDeleteWithoutUniqueDeletesMatchingObjects(): void
+    {
+        static::loadRedisFixtures(DummyHash::class);
+
+        $repo = $this->om->getRepository(DummyHash::class);
+        $deleted = $repo->bulkDelete(['name' => 'Olivier']);
+
+        $this->assertSame(2, $deleted);
+        $this->assertSame(0, $repo->count(['name' => 'Olivier']));
+        $this->assertSame(1, $repo->count(['name' => 'Kevin']));
+    }
+
+    public function testBulkDeleteAllWithoutUniqueRemovesEverything(): void
+    {
+        static::loadRedisFixtures(DummyHash::class);
+
+        $repo = $this->om->getRepository(DummyHash::class);
+        $deleted = $repo->bulkDelete();
+
+        $this->assertSame(3, $deleted);
+        $this->assertSame(0, $repo->count());
+    }
+
+    public function testBulkDeleteEmptyCollectionReturnsZero(): void
+    {
+        $repo = $this->om->getRepository(DummyHash::class);
+        $deleted = $repo->bulkDelete();
+
+        $this->assertSame(0, $deleted);
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkDelete — single-field #[Unique]
+    // -------------------------------------------------------------------------
+
+    public function testBulkDeleteReleasesUniqueKeys(): void
+    {
+        $user1 = $this->makeUniqueHash(1, 'alice@example.com', 'Alice');
+        $user2 = $this->makeUniqueHash(2, 'bob@example.com', 'Bob');
+        $this->om->persist($user1);
+        $this->om->persist($user2);
+        $this->om->flush();
+
+        $repo = $this->om->getRepository(UniqueHash::class);
+        $deleted = $repo->bulkDelete();
+
+        $this->assertSame(2, $deleted);
+
+        // Unique keys must be released so the same emails can be reused
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $new1 = $this->makeUniqueHash(10, 'alice@example.com', 'Alice2');
+        $new2 = $this->makeUniqueHash(11, 'bob@example.com', 'Bob2');
+        $om2->persist($new1);
+        $om2->persist($new2);
+        $om2->flush();
+
+        $this->assertNotNull($om2->find(UniqueHash::class, 10));
+        $this->assertNotNull($om2->find(UniqueHash::class, 11));
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkDelete — composite #[Unique]
+    // -------------------------------------------------------------------------
+
+    public function testBulkDeleteReleasesCompositeUniqueKeys(): void
+    {
+        $user1 = $this->makeCompositeHash(1, 'john', 1, 'john@t1.com');
+        $user2 = $this->makeCompositeHash(2, 'john', 2, 'john@t2.com');
+        $this->om->persist($user1);
+        $this->om->persist($user2);
+        $this->om->flush();
+
+        $repo = $this->om->getRepository(CompositeUniqueHash::class);
+        $deleted = $repo->bulkDelete(['username' => 'john']);
+
+        $this->assertSame(2, $deleted);
+
+        // Composite unique keys released: same username+tenantId combos must be reusable
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $new1 = $this->makeCompositeHash(10, 'john', 1, 'john@t1-new.com');
+        $new2 = $this->makeCompositeHash(11, 'john', 2, 'john@t2-new.com');
+        $om2->persist($new1);
+        $om2->persist($new2);
+        $om2->flush();
+
+        $this->assertNotNull($om2->find(CompositeUniqueHash::class, 10));
+        $this->assertNotNull($om2->find(CompositeUniqueHash::class, 11));
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkUpdate — non-unique fields
+    // -------------------------------------------------------------------------
+
+    public function testBulkUpdateNonUniqueFieldUpdatesMatchingObjects(): void
+    {
+        static::loadRedisFixtures(DummyHash::class);
+
+        $repo = $this->om->getRepository(DummyHash::class);
+        $updated = $repo->bulkUpdate(['name' => 'Olivier'], ['age' => 99]);
+
+        $this->assertSame(2, $updated);
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $repo2 = $om2->getRepository(DummyHash::class);
+        foreach ($repo2->findBy(['name' => 'Olivier']) as $obj) {
+            $this->assertSame(99, $obj->age);
+        }
+    }
+
+    public function testBulkUpdateLeavesNonMatchingObjectsUntouched(): void
+    {
+        static::loadRedisFixtures(DummyHash::class);
+
+        $repo = $this->om->getRepository(DummyHash::class);
+        $repo->bulkUpdate(['name' => 'Olivier'], ['age' => 99]);
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $kevin = $om2->getRepository(DummyHash::class)->findOneBy(['name' => 'Kevin']);
+        $this->assertNotNull($kevin);
+        $this->assertSame(18, $kevin->age);
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkUpdate — unique field throws
+    // -------------------------------------------------------------------------
+
+    public function testBulkUpdateOnUniqueFieldThrowsBulkOperationException(): void
+    {
+        $repo = $this->om->getRepository(UniqueHash::class);
+
+        $this->expectException(BulkOperationException::class);
+        $repo->bulkUpdate([], ['email' => 'new@example.com']);
+    }
+
+    public function testBulkUpdateExceptionMessageContainsFieldName(): void
+    {
+        $repo = $this->om->getRepository(UniqueHash::class);
+
+        try {
+            $repo->bulkUpdate([], ['email' => 'new@example.com']);
+            $this->fail('Expected BulkOperationException');
+        } catch (BulkOperationException $e) {
+            $this->assertStringContainsString('email', $e->getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makeUniqueHash(int $id, string $email, string $name): UniqueHash
+    {
+        $u = new UniqueHash();
+        $u->id = $id;
+        $u->email = $email;
+        $u->name = $name;
+
+        return $u;
+    }
+
+    private function makeCompositeHash(int $id, string $username, int $tenantId, string $email): CompositeUniqueHash
+    {
+        $u = new CompositeUniqueHash();
+        $u->id = $id;
+        $u->username = $username;
+        $u->tenantId = $tenantId;
+        $u->email = $email;
+
+        return $u;
+    }
+}

--- a/tests/Functionnal/Om/Bulk/BulkJsonTest.php
+++ b/tests/Functionnal/Om/Bulk/BulkJsonTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Talleu\RedisOm\Tests\Functionnal\Om\Bulk;
+
+use Talleu\RedisOm\Exception\BulkOperationException;
+use Talleu\RedisOm\Om\RedisObjectManager;
+use Talleu\RedisOm\Tests\Fixtures\Json\CompositeUniqueJson;
+use Talleu\RedisOm\Tests\Fixtures\Json\DummyJson;
+use Talleu\RedisOm\Tests\Fixtures\Json\UniqueJson;
+use Talleu\RedisOm\Tests\RedisAbstractTestCase;
+
+final class BulkJsonTest extends RedisAbstractTestCase
+{
+    private RedisObjectManager $om;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->om = new RedisObjectManager(self::createRedisClient());
+        static::emptyRedis();
+        static::generateIndex();
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkDelete — no unique constraints
+    // -------------------------------------------------------------------------
+
+    public function testBulkDeleteWithoutUniqueDeletesMatchingObjects(): void
+    {
+        static::loadRedisFixtures(DummyJson::class);
+
+        $repo = $this->om->getRepository(DummyJson::class);
+        $deleted = $repo->bulkDelete(['name' => 'Olivier']);
+
+        $this->assertSame(2, $deleted);
+        $this->assertSame(0, $repo->count(['name' => 'Olivier']));
+        $this->assertSame(1, $repo->count(['name' => 'Kevin']));
+    }
+
+    public function testBulkDeleteAllWithoutUniqueRemovesEverything(): void
+    {
+        static::loadRedisFixtures(DummyJson::class);
+
+        $repo = $this->om->getRepository(DummyJson::class);
+        $deleted = $repo->bulkDelete();
+
+        $this->assertSame(3, $deleted);
+        $this->assertSame(0, $repo->count());
+    }
+
+    public function testBulkDeleteEmptyCollectionReturnsZero(): void
+    {
+        $repo = $this->om->getRepository(DummyJson::class);
+        $deleted = $repo->bulkDelete();
+
+        $this->assertSame(0, $deleted);
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkDelete — single-field #[Unique]
+    // -------------------------------------------------------------------------
+
+    public function testBulkDeleteReleasesUniqueKeys(): void
+    {
+        $user1 = $this->makeUniqueJson(1, 'alice@example.com', 'Alice');
+        $user2 = $this->makeUniqueJson(2, 'bob@example.com', 'Bob');
+        $this->om->persist($user1);
+        $this->om->persist($user2);
+        $this->om->flush();
+
+        $repo = $this->om->getRepository(UniqueJson::class);
+        $deleted = $repo->bulkDelete();
+
+        $this->assertSame(2, $deleted);
+
+        // Unique keys must be released so the same emails can be reused
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $new1 = $this->makeUniqueJson(10, 'alice@example.com', 'Alice2');
+        $new2 = $this->makeUniqueJson(11, 'bob@example.com', 'Bob2');
+        $om2->persist($new1);
+        $om2->persist($new2);
+        $om2->flush();
+
+        $this->assertNotNull($om2->find(UniqueJson::class, 10));
+        $this->assertNotNull($om2->find(UniqueJson::class, 11));
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkDelete — composite #[Unique]
+    // -------------------------------------------------------------------------
+
+    public function testBulkDeleteReleasesCompositeUniqueKeys(): void
+    {
+        $user1 = $this->makeCompositeJson(1, 'john', 1, 'john@t1.com');
+        $user2 = $this->makeCompositeJson(2, 'john', 2, 'john@t2.com');
+        $this->om->persist($user1);
+        $this->om->persist($user2);
+        $this->om->flush();
+
+        $repo = $this->om->getRepository(CompositeUniqueJson::class);
+        $deleted = $repo->bulkDelete(['username' => 'john']);
+
+        $this->assertSame(2, $deleted);
+
+        // Composite unique keys released: same username+tenantId combos must be reusable
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $new1 = $this->makeCompositeJson(10, 'john', 1, 'john@t1-new.com');
+        $new2 = $this->makeCompositeJson(11, 'john', 2, 'john@t2-new.com');
+        $om2->persist($new1);
+        $om2->persist($new2);
+        $om2->flush();
+
+        $this->assertNotNull($om2->find(CompositeUniqueJson::class, 10));
+        $this->assertNotNull($om2->find(CompositeUniqueJson::class, 11));
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkUpdate — non-unique fields
+    // -------------------------------------------------------------------------
+
+    public function testBulkUpdateNonUniqueFieldUpdatesMatchingObjects(): void
+    {
+        static::loadRedisFixtures(DummyJson::class);
+
+        $repo = $this->om->getRepository(DummyJson::class);
+        $updated = $repo->bulkUpdate(['name' => 'Olivier'], ['age' => 99]);
+
+        $this->assertSame(2, $updated);
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $repo2 = $om2->getRepository(DummyJson::class);
+        foreach ($repo2->findBy(['name' => 'Olivier']) as $obj) {
+            $this->assertSame(99, $obj->age);
+        }
+    }
+
+    public function testBulkUpdateLeavesNonMatchingObjectsUntouched(): void
+    {
+        static::loadRedisFixtures(DummyJson::class);
+
+        $repo = $this->om->getRepository(DummyJson::class);
+        $repo->bulkUpdate(['name' => 'Olivier'], ['age' => 99]);
+
+        $om2 = new RedisObjectManager(self::createRedisClient());
+        $kevin = $om2->getRepository(DummyJson::class)->findOneBy(['name' => 'Kevin']);
+        $this->assertNotNull($kevin);
+        $this->assertSame(18, $kevin->age);
+    }
+
+    // -------------------------------------------------------------------------
+    // bulkUpdate — unique field throws
+    // -------------------------------------------------------------------------
+
+    public function testBulkUpdateOnUniqueFieldThrowsBulkOperationException(): void
+    {
+        $repo = $this->om->getRepository(UniqueJson::class);
+
+        $this->expectException(BulkOperationException::class);
+        $repo->bulkUpdate([], ['email' => 'new@example.com']);
+    }
+
+    public function testBulkUpdateExceptionMessageContainsFieldName(): void
+    {
+        $repo = $this->om->getRepository(UniqueJson::class);
+
+        try {
+            $repo->bulkUpdate([], ['email' => 'new@example.com']);
+            $this->fail('Expected BulkOperationException');
+        } catch (BulkOperationException $e) {
+            $this->assertStringContainsString('email', $e->getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makeUniqueJson(int $id, string $email, string $name): UniqueJson
+    {
+        $u = new UniqueJson();
+        $u->id = $id;
+        $u->email = $email;
+        $u->name = $name;
+
+        return $u;
+    }
+
+    private function makeCompositeJson(int $id, string $username, int $tenantId, string $email): CompositeUniqueJson
+    {
+        $u = new CompositeUniqueJson();
+        $u->id = $id;
+        $u->username = $username;
+        $u->tenantId = $tenantId;
+        $u->email = $email;
+
+        return $u;
+    }
+}


### PR DESCRIPTION
Ref: https://github.com/clementtalleu/php-redis-om/issues/146

Implement BulkOperations without loading objects into memory:
- ClassMetadata: expose uniqueConstraints, hasUniqueConstraints(), getUniqueFields()
- MetadataFactory: read #[Unique] property-level and class-level into ClassMetadata
- RedisObjectManager: cache ClassMetadata per class; refactor buildUniqueConstraintPlan() to read pre-computed metadata instead of repeating reflection on every flush()
- AbstractObjectRepository: lazy ClassMetadata cache via getClassMetadata()
- RedisClientInterface + RedisClient + PredisClient: three new methods:
  - searchKeys()             FT.SEARCH ... NOCONTENT (keys only, no deserialization)
  - searchKeysWithFields()   FT.SEARCH ... RETURN n fields (keys + selected field values)
  - delMultiple()            DEL key1 key2 ... (single command)
- bulkDelete(criteria): FT.SEARCH per batch + delMultiple; unique constraint keys
      (unique:{class}:{fields}:{values}) cleaned up automatically
- bulkUpdate(criteria, changes): FT.SEARCH per batch + hMSet/jsonSetProperty per key;
      throws BulkOperationException when changes target a unique-constraint field
- BulkOperationException: new exception for invalid bulk update on unique fields
- Functional tests: 18 tests covering Hash and JSON for all scenarios
- docs/advanced_usage.md: bulk operations section with decision table
- README.md: Bulk Operations section + feature list entry
